### PR TITLE
feat: added delete confirmation modal to builder issue #76

### DIFF
--- a/apps/web/components/common/DeleteConfirmation.tsx
+++ b/apps/web/components/common/DeleteConfirmation.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@workspace/ui/components/dialog";
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
+import { Alert, AlertDescription } from "@workspace/ui/components/alert";
+import { Trash2, AlertTriangle } from "lucide-react";
+
+interface DeleteConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  itemName: string;
+  itemType: "Pillar" | "KPI";
+  title?: string;
+  description?: string;
+  isLoading?: boolean;
+}
+
+export function DeleteConfirmationModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  itemName,
+  itemType,
+  title,
+  description,
+  isLoading = false,
+}: DeleteConfirmationModalProps) {
+  const [confirmationText, setConfirmationText] = useState("");
+  const [showError, setShowError] = useState(false);
+
+  const isConfirmationValid = confirmationText === itemName;
+  const defaultTitle = `Delete ${itemType}`;
+  const defaultDescription = `By deleting this ${itemType.toLowerCase()} you will also delete all associated data, reviews, and assignments. This action cannot be undone.`;
+
+  const handleConfirm = () => {
+    if (!isConfirmationValid) {
+      setShowError(true);
+      return;
+    }
+    onConfirm();
+  };
+
+  const handleClose = () => {
+    setConfirmationText("");
+    setShowError(false);
+    onClose();
+  };
+
+  const handleInputChange = (value: string) => {
+    setConfirmationText(value);
+    if (showError && value === itemName) {
+      setShowError(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-red-600">
+            <Trash2 className="h-5 w-5" />
+            {title || defaultTitle}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Warning Alert */}
+          <Alert className="border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
+            <AlertTriangle className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800 dark:text-red-200">
+              {description || defaultDescription}
+            </AlertDescription>
+          </Alert>
+
+          {/* Item Name Display */}
+          <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-lg">
+            <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">
+              {itemType} to be deleted:
+            </div>
+            <div className="font-semibold text-gray-900 dark:text-gray-100">
+              {itemName}
+            </div>
+          </div>
+
+          {/* Confirmation Input */}
+          <div className="space-y-2">
+            <Label htmlFor="confirmation-input" className="text-sm font-medium">
+              Type{" "}
+              <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">
+                {itemName}
+              </span>{" "}
+              to confirm:
+            </Label>
+            <Input
+              id="confirmation-input"
+              type="text"
+              value={confirmationText}
+              onChange={(e) => handleInputChange(e.target.value)}
+              placeholder={`Type "${itemName}" here`}
+              className={`${
+                showError && !isConfirmationValid
+                  ? "border-red-500 focus:border-red-500 focus:ring-red-500"
+                  : ""
+              }`}
+              disabled={isLoading}
+            />
+            {showError && !isConfirmationValid && (
+              <p className="text-sm text-red-600">
+                Please type the exact {itemType.toLowerCase()} name to confirm
+                deletion.
+              </p>
+            )}
+          </div>
+
+          {/* Progress indicator */}
+          {confirmationText && (
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              {confirmationText === itemName ? (
+                <span className="text-green-600 dark:text-green-400">
+                  ✓ Confirmation text matches
+                </span>
+              ) : (
+                <span>
+                  {confirmationText.length}/{itemName.length} characters
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex gap-2">
+          <Button variant="outline" onClick={handleClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={!isConfirmationValid || isLoading}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            {isLoading ? (
+              <>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                Deleting...
+              </>
+            ) : (
+              <>
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete {itemType}
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/qc/delete-confirmation.tsx
+++ b/apps/web/components/qc/delete-confirmation.tsx
@@ -19,7 +19,7 @@ interface DeleteConfirmationModalProps {
   onClose: () => void;
   onConfirm: () => void;
   itemName: string;
-  itemType: "pillar" | "KPI";
+  itemType: "Pillar" | "KPI";
   title?: string;
   description?: string;
   isLoading?: boolean;

--- a/apps/web/components/qc/pillar/PillarCard.tsx
+++ b/apps/web/components/qc/pillar/PillarCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useState } from "react";
 import {
   Card,
   CardContent,
@@ -10,6 +12,7 @@ import { Button } from "@workspace/ui/components/button";
 import { Edit2, Trash2, Plus } from "lucide-react";
 
 import { PillarInstance } from "@workspace/types/types";
+import { DeleteConfirmationModal } from "@/components/qc/delete-confirmation";
 
 interface PillarCardProps {
   pillar: PillarInstance;
@@ -32,106 +35,117 @@ export function PillarCard({
   kpiCount = 0,
   isDeleting = false,
 }: PillarCardProps) {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   return (
-    <Card
-      className={`cursor-pointer transition-all duration-200 hover:shadow-lg ${
-        isSelected
-          ? "ring-2 ring-primary bg-primary/5 border-primary"
-          : "hover:border-primary/50"
-      }`}
-      onClick={() => onSelect(pillar)}
-    >
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between">
-          <div className="flex-1">
-            <CardTitle className="text-lg font-semibold">
-              {pillar.name}
-            </CardTitle>
-            <CardDescription className="mt-1">
-              Pillar #{pillar.id}
-            </CardDescription>
+    <>
+      <Card
+        className={`cursor-pointer transition-all duration-200 hover:shadow-lg ${
+          isSelected
+            ? "ring-2 ring-primary bg-primary/5 border-primary"
+            : "hover:border-primary/50"
+        }`}
+        onClick={() => onSelect(pillar)}
+      >
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <CardTitle className="text-lg font-semibold">
+                {pillar.name}
+              </CardTitle>
+              <CardDescription className="mt-1">
+                Pillar #{pillar.id}
+              </CardDescription>
+            </div>
+            <div className="flex flex-col items-end gap-1">
+              {pillar.counts?.assignedkpi > 0 && (
+                <Badge variant="secondary" className="text-xs">
+                  KPIs: {pillar.counts.assignedkpi}
+                </Badge>
+              )}
+              {pillar.pillar_value !== undefined && (
+                <Badge variant="outline" className="text-xs">
+                  Weight: {(pillar.pillar_value * 100).toFixed(0)}%
+                </Badge>
+              )}
+            </div>
           </div>
-          <div className="flex flex-col items-end gap-1">
-            {pillar.counts?.assignedkpi > 0 && (
-              <Badge variant="secondary" className="text-xs">
-                KPIs: {pillar.counts.assignedkpi}
-              </Badge>
-            )}
-            {pillar.pillar_value !== undefined && (
-              <Badge variant="outline" className="text-xs">
-                Weight: {(pillar.pillar_value * 100).toFixed(0)}%
-              </Badge>
-            )}
-          </div>
-        </div>
-      </CardHeader>
+        </CardHeader>
 
-      <CardContent className="pt-0">
-        <div className="space-y-3">
-          {pillar.description && (
-            <div className="text-sm text-muted-foreground">
-              <p
-                className="overflow-hidden"
-                style={{
-                  display: "-webkit-box",
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: "vertical",
-                  lineHeight: "1.4em",
-                  maxHeight: "2.8em",
+        <CardContent className="pt-0">
+          <div className="space-y-3">
+            {pillar.description && (
+              <div className="text-sm text-muted-foreground">
+                <p
+                  className="overflow-hidden"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                    lineHeight: "1.4em",
+                    maxHeight: "2.8em",
+                  }}
+                >
+                  {pillar.description}
+                </p>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">KPI Count:</span>
+              <span className="font-medium">{kpiCount}</span>
+            </div>
+
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                className="flex-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCreateKpi(pillar);
                 }}
               >
-                {pillar.description}
-              </p>
+                <Plus className="w-4 h-4 mr-1" />
+                Add KPI
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(pillar);
+                }}
+              >
+                <Edit2 className="w-4 h-4" />
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="text-destructive hover:text-destructive"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsDeleteModalOpen(true);
+                }}
+                disabled={isDeleting}
+              >
+                {isDeleting ? (
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-destructive"></div>
+                ) : (
+                  <Trash2 className="w-4 h-4" />
+                )}
+              </Button>
             </div>
-          )}
-
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">KPI Count:</span>
-            <span className="font-medium">{kpiCount}</span>
           </div>
-
-          <div className="flex gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              className="flex-1"
-              onClick={(e) => {
-                e.stopPropagation();
-                onCreateKpi(pillar);
-              }}
-            >
-              <Plus className="w-4 h-4 mr-1" />
-              Add KPI
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit(pillar);
-              }}
-            >
-              <Edit2 className="w-4 h-4" />
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              className="text-destructive hover:text-destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(pillar.id);
-              }}
-              disabled={isDeleting}
-            >
-              {isDeleting ? (
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-destructive"></div>
-              ) : (
-                <Trash2 className="w-4 h-4" />
-              )}
-            </Button>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+      <DeleteConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={() => onDelete(pillar.id)}
+        itemName={pillar.name}
+        itemType="Pillar"
+        isLoading={isDeleting}
+      />
+    </>
   );
 }

--- a/apps/web/components/qc/pillar/PillarCard.tsx
+++ b/apps/web/components/qc/pillar/PillarCard.tsx
@@ -12,7 +12,7 @@ import { Button } from "@workspace/ui/components/button";
 import { Edit2, Trash2, Plus } from "lucide-react";
 
 import { PillarInstance } from "@workspace/types/types";
-import { DeleteConfirmationModal } from "@/components/qc/delete-confirmation";
+import { DeleteConfirmationModal } from "@/components/common/DeleteConfirmation";
 
 interface PillarCardProps {
   pillar: PillarInstance;


### PR DESCRIPTION
Added Delete modal component to Pillar deletion on /qc/builder page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a delete confirmation modal requiring users to type the item name to confirm deletion.
  * Integrated the delete confirmation modal into pillar cards to prevent accidental deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->