### PR TITLE
feat: assign and unassign kpi from a dept per pillar

### DIFF
--- a/apps/server/src/qc/department-assignment/department-assignment.controller.ts
+++ b/apps/server/src/qc/department-assignment/department-assignment.controller.ts
@@ -59,4 +59,32 @@ export class DepartmentAssignmentController {
   getDepartmentPillarKPIs(@CurrentUser() user: RequestUser, @Param('departmentPillarId') departmentPillarId: string) {
     return this.departmentAssignmentService.getDepartmentPillarKPIs(user.id, user.role, departmentPillarId);
   }
+
+  /**
+   * Assign a KPI template to a department pillar
+   * POST /qc/department-assignment/department-pillars/:departmentPillarId/kpis
+   * Body: { kpiTemplateId: string }
+   */
+  @Post('department-pillars/:departmentPillarId/kpis')
+  assignKpiToDepartmentPillar(
+    @CurrentUser() user: RequestUser,
+    @Param('departmentPillarId') departmentPillarId: string,
+    @Body() body: { kpiTemplateId: string },
+  ) {
+    return this.departmentAssignmentService.assignKpiToDepartmentPillar(
+      user.id,
+      user.role,
+      departmentPillarId,
+      body.kpiTemplateId,
+    );
+  }
+
+  /**
+   * Unassign a KPI from a department pillar
+   * DELETE /qc/department-assignment/department-kpis/:departmentKpiId
+   */
+  @Delete('department-kpis/:departmentKpiId')
+  unassignKpiFromDepartmentPillar(@CurrentUser() user: RequestUser, @Param('departmentKpiId') departmentKpiId: string) {
+    return this.departmentAssignmentService.unassignKpiFromDepartmentPillar(user.id, user.role, departmentKpiId);
+  }
 }

--- a/apps/server/src/qc/department-assignment/department-assignment.service.ts
+++ b/apps/server/src/qc/department-assignment/department-assignment.service.ts
@@ -306,4 +306,103 @@ export class DepartmentAssignmentService {
       return cw.coordinator_status === 'APPROVED_BY_HOD';
     });
   }
+
+  /**
+   * Assigns a KPI template to a department pillar (creates DepartmentKpi)
+   * @param userId - The QAC's user ID
+   * @param userRole - The QAC's role
+   * @param departmentPillarId - The department pillar ID
+   * @param kpiTemplateId - The KPI template ID
+   * @returns Success message and created DepartmentKpi
+   */
+  async assignKpiToDepartmentPillar(
+    userId: string,
+    userRole: UserRole,
+    departmentPillarId: string,
+    kpiTemplateId: string,
+  ) {
+    if (!userId) throw new ForbiddenException('User not authenticated');
+    this.assertQacRole(userRole);
+
+    // Check if department pillar exists
+    const departmentPillar = await this.prisma.departmentPillar.findUnique({
+      where: { id: departmentPillarId },
+    });
+    if (!departmentPillar) {
+      throw new NotFoundException('Department pillar not found');
+    }
+
+    // Check if KPI template exists
+    const kpiTemplate = await this.prisma.kpiTemplate.findUnique({
+      where: { id: kpiTemplateId },
+    });
+    if (!kpiTemplate) {
+      throw new NotFoundException('KPI template not found');
+    }
+
+    // Check if already assigned
+    const existing = await this.prisma.departmentKpi.findUnique({
+      where: {
+        dept_pillar_id_template_id: {
+          dept_pillar_id: departmentPillarId,
+          template_id: kpiTemplateId,
+        },
+      },
+    });
+    if (existing) {
+      throw new ForbiddenException('KPI already assigned to this pillar');
+    }
+
+    // Create DepartmentKpi
+    const kpiDataJson = kpiTemplate.kpi_data ? JSON.parse(JSON.stringify(kpiTemplate.kpi_data)) : null;
+    const metricsJson = kpiTemplate.kpi_calculated_metrics
+      ? JSON.parse(JSON.stringify(kpiTemplate.kpi_calculated_metrics))
+      : null;
+    const departmentKpi = await this.prisma.departmentKpi.create({
+      data: {
+        dept_id: departmentPillar.dept_id,
+        dept_pillar_id: departmentPillarId,
+        template_id: kpiTemplateId,
+        kpi_number: kpiTemplate.kpi_number,
+        kpi_metric_name: kpiTemplate.kpi_metric_name,
+        kpi_description: kpiTemplate.kpi_description,
+        kpi_value: kpiTemplate.kpi_value,
+        data_provided_by: kpiTemplate.data_provided_by,
+        kpi_data: kpiDataJson ?? undefined,
+        kpi_calculated_metrics: metricsJson ?? undefined,
+        academic_year: new Date().getFullYear(),
+      },
+    });
+    return {
+      message: 'KPI assigned to department pillar successfully',
+      departmentKpi,
+    };
+  }
+
+  /**
+   * Unassigns a KPI from a department pillar (deletes DepartmentKpi)
+   * @param userId - The QAC's user ID
+   * @param userRole - The QAC's role
+   * @param departmentKpiId - The DepartmentKpi ID
+   * @returns Success message
+   */
+  async unassignKpiFromDepartmentPillar(userId: string, userRole: UserRole, departmentKpiId: string) {
+    if (!userId) throw new ForbiddenException('User not authenticated');
+    this.assertQacRole(userRole);
+
+    // Check if DepartmentKpi exists
+    const departmentKpi = await this.prisma.departmentKpi.findUnique({
+      where: { id: departmentKpiId },
+    });
+    if (!departmentKpi) {
+      throw new NotFoundException('Department KPI not found');
+    }
+
+    await this.prisma.departmentKpi.delete({
+      where: { id: departmentKpiId },
+    });
+    return {
+      message: 'KPI unassigned from department pillar successfully',
+    };
+  }
 }

--- a/apps/web/app/(dashboards)/qc/assign/page.tsx
+++ b/apps/web/app/(dashboards)/qc/assign/page.tsx
@@ -28,6 +28,8 @@ import {
   useGetDepartmentPillarKPIs,
   useAssignPillarToDepartment,
   useUnassignPillarFromDepartment,
+  useAssignKpiToDepartmentPillar,
+  useUnassignKpiFromDepartmentPillar,
 } from "@/queries/qc/department-assignment";
 
 export default function AssignKpiToDepartmentPage() {
@@ -65,6 +67,8 @@ export default function AssignKpiToDepartmentPage() {
   // Mutations
   const assignPillarMutation = useAssignPillarToDepartment();
   const unassignPillarMutation = useUnassignPillarFromDepartment();
+  const assignKpiMutation = useAssignKpiToDepartmentPillar();
+  const unassignKpiMutation = useUnassignKpiFromDepartmentPillar();
 
   // Compute assigned and unassigned pillars
   const { assignedPillars, unassignedPillars } = useMemo(() => {
@@ -211,18 +215,36 @@ export default function AssignKpiToDepartmentPage() {
     });
   };
 
-  // Handle assigning a KPI to a pillar (placeholder for future implementation)
+  // Handle assigning a KPI to a pillar
   const handleAssignKpi = (kpi: { id: string; kpi_metric_name: string }) => {
-    toast.info(
-      "KPI assignment functionality will be implemented in the next phase",
-    );
+    if (!selectedDepartmentPillar) {
+      toast.error("No department pillar selected");
+      return;
+    }
+    assignKpiMutation.mutate({
+      departmentPillarId: selectedDepartmentPillar.id,
+      kpiTemplateId: kpi.id,
+    });
   };
 
-  // Handle unassigning a KPI from a pillar (placeholder for future implementation)
+  // Handle unassigning a KPI from a pillar
   const handleUnassignKpi = (kpi: { id: string; kpi_metric_name: string }) => {
-    toast.info(
-      "KPI unassignment functionality will be implemented in the next phase",
+    if (!selectedDepartmentPillar) {
+      toast.error("No department pillar selected");
+      return;
+    }
+    // Find the DepartmentKpi object for this KPI template
+    const departmentKpi = departmentPillarKPIs.find(
+      (dk) => dk.template_id === kpi.id,
     );
+    if (!departmentKpi) {
+      toast.error("KPI not found in department pillar");
+      return;
+    }
+    unassignKpiMutation.mutate({
+      departmentKpiId: departmentKpi.id,
+      departmentPillarId: selectedDepartmentPillar.id,
+    });
   };
 
   // Loading states
@@ -417,30 +439,6 @@ export default function AssignKpiToDepartmentPage() {
                     ?.pillar_name || "KPIs for Pillar"}
                 </CardTitle>
               </CardHeader>
-
-              {/* Debug Info */}
-              <CardContent className="bg-muted/50">
-                <div className="text-sm space-y-1">
-                  <p>
-                    <strong>Debug Info:</strong>
-                  </p>
-                  <p>Selected Pillar ID: {selectedPillarId}</p>
-                  <p>
-                    Department Pillar ID:{" "}
-                    {selectedDepartmentPillar?.id || "Not found"}
-                  </p>
-                  <p>
-                    Department Pillar KPIs Count: {departmentPillarKPIs.length}
-                  </p>
-                  <p>Assigned KPIs Count: {assignedKpis.length}</p>
-                  <p>Unassigned KPIs Count: {unassignedKpis.length}</p>
-                  <p>
-                    Template KPIs Count:{" "}
-                    {pillarTemplates.find((p) => p.id === selectedPillarId)
-                      ?.kpi_templates.length || 0}
-                  </p>
-                </div>
-              </CardContent>
 
               <CardContent>
                 <AssignKpiTable

--- a/apps/web/components/qc/assign/AssignKpiTable.tsx
+++ b/apps/web/components/qc/assign/AssignKpiTable.tsx
@@ -24,70 +24,37 @@ export function AssignKpiTable({
   onAssign,
   onUnassign,
 }: AssignKpiTableProps) {
-  // Make value editable and track state
-  const [assigned, setAssigned] = React.useState(assignedKpis);
-  const [unassigned, setUnassigned] = React.useState(unassignedKpis);
+  // Combine all KPIs into one list and track their states
+  const allKpis = React.useMemo(() => {
+    const assignedIds = new Set(assignedKpis.map((kpi) => kpi.id));
+    return [...assignedKpis, ...unassignedKpis]
+      .sort((a, b) => (a.kpiNo ?? a.kpi_number) - (b.kpiNo ?? b.kpi_number))
+      .map((kpi) => ({
+        ...kpi,
+        isAssigned: assignedIds.has(kpi.id),
+      }));
+  }, [assignedKpis, unassignedKpis]);
+
+  const [kpiValues, setKpiValues] = React.useState<Record<string, string>>({});
 
   React.useEffect(() => {
-    setAssigned(assignedKpis);
-  }, [assignedKpis]);
-  React.useEffect(() => {
-    setUnassigned(unassignedKpis);
-  }, [unassignedKpis]);
+    // Initialize or update values from props
+    const newValues: Record<string, string> = {};
+    allKpis.forEach((kpi) => {
+      newValues[kpi.id] = kpi.value ?? "";
+    });
+    setKpiValues(newValues);
+  }, [allKpis]);
 
-  const handleValueChange = (
-    type: "assigned" | "unassigned",
-    idx: number,
-    newValue: string,
-  ) => {
-    if (type === "assigned") {
-      setAssigned((prev) =>
-        prev.map((kpi, i) => (i === idx ? { ...kpi, value: newValue } : kpi)),
-      );
-    } else {
-      setUnassigned((prev) =>
-        prev.map((kpi, i) => (i === idx ? { ...kpi, value: newValue } : kpi)),
-      );
-    }
+  const handleValueChange = (kpiId: string, newValue: string) => {
+    setKpiValues((prev) => ({
+      ...prev,
+      [kpiId]: newValue,
+    }));
   };
-
-  const totalAssignedValue = assigned.reduce(
-    (sum, kpi) => sum + Number(kpi.value ?? 0),
-    0,
-  );
-  const totalUnassignedValue = unassigned.reduce(
-    (sum, kpi) => sum + Number(kpi.value ?? 0),
-    0,
-  );
 
   return (
     <Card className="p-4">
-      <div className="flex justify-end gap-2 mb-2">
-        <Button
-          size="sm"
-          variant={unassigned.length > 0 ? "default" : "outline"}
-          className={
-            unassigned.length > 0 ? "" : "opacity-50 cursor-not-allowed"
-          }
-          disabled={unassigned.length === 0}
-          onClick={() => {
-            unassigned.forEach(onAssign);
-          }}
-        >
-          Assign All
-        </Button>
-        <Button
-          size="sm"
-          variant={assigned.length > 0 ? "destructive" : "outline"}
-          className={assigned.length > 0 ? "" : "opacity-50 cursor-not-allowed"}
-          disabled={assigned.length === 0}
-          onClick={() => {
-            assigned.forEach(onUnassign);
-          }}
-        >
-          Unassign All
-        </Button>
-      </div>
       <Table className="min-w-full table-fixed border-separate border-spacing-0">
         <TableHeader>
           <TableRow>
@@ -107,94 +74,69 @@ export function AssignKpiTable({
               Value
             </TableHead>
             <TableHead className="text-center align-middle w-32">
-              Action
+              Status
             </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {assigned.map((kpi, idx) => (
+          {allKpis.map((kpi) => (
             <TableRow key={kpi.id}>
               <TableCell className="text-center align-middle">
-                {kpi.kpiNo ?? kpi.kpi_no ?? kpi.title ?? "-"}
+                {kpi.kpiNo ?? kpi.kpi_number ?? kpi.kpi_no ?? "-"}
               </TableCell>
               <TableCell className="text-left align-middle">
-                {kpi.metric ?? kpi.title ?? "-"}
+                {kpi.metric ?? kpi.kpi_metric_name ?? "-"}
               </TableCell>
               <TableCell className="text-center align-middle">
-                {kpi.dataProvidedBy ?? "-"}
+                {kpi.dataProvidedBy ?? kpi.data_provided_by ?? "-"}
               </TableCell>
               <TableCell className="text-center align-middle">
-                {kpi.target2025 ?? kpi.target ?? "-"}
+                {kpi.target2025 ?? kpi.kpi_value ?? kpi.target ?? "-"}
               </TableCell>
               <TableCell className="text-center align-middle">
                 <Input
                   className="w-24 text-center"
-                  value={kpi.value ?? ""}
-                  onChange={(e) =>
-                    handleValueChange("assigned", idx, e.target.value)
-                  }
+                  value={kpiValues[kpi.id] ?? ""}
+                  onChange={(e) => handleValueChange(kpi.id, e.target.value)}
                 />
               </TableCell>
               <TableCell className="text-center align-middle">
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  className="text-xs px-2 py-1"
-                  onClick={() => onUnassign(kpi)}
-                  disabled={false}
-                >
-                  Unassign
-                </Button>
-              </TableCell>
-            </TableRow>
-          ))}
-          {unassigned.map((kpi, idx) => (
-            <TableRow key={kpi.id}>
-              <TableCell className="text-center align-middle">
-                {kpi.kpiNo ?? kpi.kpi_no ?? kpi.title ?? "-"}
-              </TableCell>
-              <TableCell className="text-left align-middle">
-                {kpi.metric ?? kpi.title ?? "-"}
-              </TableCell>
-              <TableCell className="text-center align-middle">
-                {kpi.dataProvidedBy ?? "-"}
-              </TableCell>
-              <TableCell className="text-center align-middle">
-                {kpi.target2025 ?? kpi.target ?? "-"}
-              </TableCell>
-              <TableCell className="text-center align-middle">
-                <Input
-                  className="w-24 text-center"
-                  value={kpi.value ?? ""}
-                  onChange={(e) =>
-                    handleValueChange("unassigned", idx, e.target.value)
-                  }
-                />
-              </TableCell>
-              <TableCell className="text-center align-middle">
-                <Button
-                  size="sm"
-                  variant="default"
-                  className="text-xs px-2 py-1"
-                  onClick={() => onAssign(kpi)}
-                  disabled={false}
-                >
-                  Assign
-                </Button>
+                {kpi.isAssigned ? (
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="text-xs px-2 py-1"
+                    onClick={() => onUnassign(kpi)}
+                  >
+                    Unassign
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="default"
+                    className="text-xs px-2 py-1"
+                    onClick={() => onAssign(kpi)}
+                  >
+                    Assign
+                  </Button>
+                )}
               </TableCell>
             </TableRow>
           ))}
         </TableBody>
         <tfoot>
-          {assigned.length > 0 && (
-            <tr>
-              <td colSpan={4} className="font-bold text-right">
-                Total Value (Assigned)
-              </td>
-              <td className="font-bold text-center">{totalAssignedValue}</td>
-              <td />
-            </tr>
-          )}
+          <tr>
+            <td colSpan={4} className="font-bold text-right">
+              Total Value
+            </td>
+            <td className="font-bold text-center">
+              {Object.values(kpiValues).reduce(
+                (sum, value) => sum + (Number(value) || 0),
+                0,
+              )}
+            </td>
+            <td />
+          </tr>
         </tfoot>
       </Table>
     </Card>

--- a/apps/web/queries/qc/department-assignment.ts
+++ b/apps/web/queries/qc/department-assignment.ts
@@ -8,6 +8,8 @@ import {
   assignPillarToDepartment,
   unassignPillarFromDepartment,
   getDepartmentPillarKPIs,
+  assignKpiToDepartmentPillar,
+  unassignKpiFromDepartmentPillar,
   Department,
   PillarTemplate,
   DepartmentPillar,
@@ -181,6 +183,79 @@ export function useUnassignPillarFromDepartment() {
     },
     onError: (error: any) => {
       toast.error("Failed to unassign pillar from department", {
+        description: error.message || "An error occurred",
+      });
+    },
+  });
+}
+
+/**
+ * React Query mutation hook for assigning KPI to department pillar
+ * @returns Mutation object with assign KPI functionality
+ */
+export function useAssignKpiToDepartmentPillar() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      departmentPillarId,
+      kpiTemplateId,
+    }: {
+      departmentPillarId: string;
+      kpiTemplateId: string;
+    }) => {
+      const res = await assignKpiToDepartmentPillar(
+        departmentPillarId,
+        kpiTemplateId,
+      );
+      if (res.data) return res.data;
+      throw new Error(
+        res.error?.message || "Failed to assign KPI to department pillar",
+      );
+    },
+    onSuccess: (data, variables) => {
+      // Invalidate and refetch KPIs for the department pillar
+      queryClient.invalidateQueries({
+        queryKey: ["qc-department-pillar-kpis", variables.departmentPillarId],
+      });
+      toast.success(data.message);
+    },
+    onError: (error: any) => {
+      toast.error("Failed to assign KPI to department pillar", {
+        description: error.message || "An error occurred",
+      });
+    },
+  });
+}
+
+/**
+ * React Query mutation hook for unassigning KPI from department pillar
+ * @returns Mutation object with unassign KPI functionality
+ */
+export function useUnassignKpiFromDepartmentPillar() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      departmentKpiId,
+      departmentPillarId,
+    }: {
+      departmentKpiId: string;
+      departmentPillarId: string;
+    }) => {
+      const res = await unassignKpiFromDepartmentPillar(departmentKpiId);
+      if (res.data) return res.data;
+      throw new Error(
+        res.error?.message || "Failed to unassign KPI from department pillar",
+      );
+    },
+    onSuccess: (data, variables) => {
+      // Invalidate and refetch KPIs for the department pillar
+      queryClient.invalidateQueries({
+        queryKey: ["qc-department-pillar-kpis", variables.departmentPillarId],
+      });
+      toast.success(data.message);
+    },
+    onError: (error: any) => {
+      toast.error("Failed to unassign KPI from department pillar", {
         description: error.message || "An error occurred",
       });
     },

--- a/apps/web/services/qc/department-assignment.service.ts
+++ b/apps/web/services/qc/department-assignment.service.ts
@@ -238,3 +238,47 @@ export const getDepartmentPillarKPIs = async (departmentPillarId: string) => {
     throw error;
   }
 };
+
+/**
+ * Assigns a KPI template to a department pillar
+ * @param departmentPillarId - The department pillar ID
+ * @param kpiTemplateId - The KPI template ID
+ * @returns Promise with assignment response
+ */
+export const assignKpiToDepartmentPillar = async (
+  departmentPillarId: string,
+  kpiTemplateId: string,
+) => {
+  try {
+    const response = await ApiClient.post<{
+      message: string;
+      departmentKpi: DepartmentKpi;
+    }>(
+      `/qc/department-assignment/department-pillars/${departmentPillarId}/kpis`,
+      { kpiTemplateId },
+    );
+    return response;
+  } catch (error: unknown) {
+    const apiError = error as ApiError;
+    throw error;
+  }
+};
+
+/**
+ * Unassigns a KPI from a department pillar
+ * @param departmentKpiId - The DepartmentKpi ID
+ * @returns Promise with unassignment response
+ */
+export const unassignKpiFromDepartmentPillar = async (
+  departmentKpiId: string,
+) => {
+  try {
+    const response = await ApiClient.delete<{ message: string }>(
+      `/qc/department-assignment/department-kpis/${departmentKpiId}`,
+    );
+    return response;
+  } catch (error: unknown) {
+    const apiError = error as ApiError;
+    throw error;
+  }
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Assign and unassign KPIs to department pillars directly from the QC Assign page.
  - Instant feedback with success/error toasts and automatic list refresh.

- Refactor
  - Unified KPI list with clear Status actions; simplified per-KPI value inputs.
  - Removed bulk “Assign All/Unassign All” controls; added a single total value row.
  - Cleaned up UI by removing debug information sections for a clearer, more focused experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->