### PR TITLE
feat: hod row-wise comment

### DIFF
--- a/apps/server/src/hod/hod.module.ts
+++ b/apps/server/src/hod/hod.module.ts
@@ -11,10 +11,18 @@ import { HodCoordinatorWorkflowService } from './hod-coordinator-workflow.servic
 import { HodDashboardModule } from './dashboard/hod-dashboard.module';
 import { ExcelService } from 'src/services/excel.service';
 import { KpiEntriesModule } from './kpi-entries/kpi-entries.module';
+import { QcReviewService } from 'src/qc/review/qc-review.service';
 
 @Module({
   controllers: [DepartmentInfoController, CoordinatorController, HodKpiController, HodCoordinatorWorkflowController],
-  providers: [DepartmentInfoService, CoordinatorService, HodKpiService, HodCoordinatorWorkflowService, ExcelService],
+  providers: [
+    DepartmentInfoService,
+    CoordinatorService,
+    HodKpiService,
+    HodCoordinatorWorkflowService,
+    ExcelService,
+    QcReviewService,
+  ],
   imports: [PrismaModule, HodDashboardModule, KpiEntriesModule],
 })
 export class HodModule {}

--- a/apps/server/src/hod/kpi-management/kpi-management.controller.ts
+++ b/apps/server/src/hod/kpi-management/kpi-management.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Put, Param, Body, UseGuards, Post, UseInterceptors, UploadedFile } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Put,
+  Param,
+  Body,
+  UseGuards,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam, ApiConsumes, ApiBody } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { CurrentUser } from 'src/auth/decorators/user.decorator';
@@ -118,5 +129,29 @@ export class HodKpiController {
     @CurrentUser() user: RequestUser,
   ): Promise<ExcelUploadResponseDto> {
     return await this.hodKpiService.uploadExcel(user.id, user.role, kpiId, file);
+  }
+
+  @Get('/kpi/:kpiId/entry-comments')
+  @ApiOperation({ summary: 'Get entry comments for KPI' })
+  @ApiResponse({ status: 200, description: 'Returns entry comments for the KPI' })
+  async getEntryComments(@CurrentUser() user: RequestUser, @Param('kpiId') kpiId: string) {
+    return this.hodKpiService.getEntryComments(user.id, user.role, kpiId);
+  }
+
+  @Put('/kpi/:kpiId/entries/:entryIndex/comment')
+  @ApiOperation({ summary: 'Save entry comment for KPI (only when in REVISION status)' })
+  @ApiResponse({ status: 200, description: 'Entry comment saved successfully' })
+  async saveEntryComment(
+    @CurrentUser() user: RequestUser,
+    @Param('kpiId') kpiId: string,
+    @Param('entryIndex') entryIndex: string,
+    @Body() body: { comment: string },
+  ) {
+    const index = parseInt(entryIndex, 10);
+    if (isNaN(index)) {
+      throw new BadRequestException('Invalid entry index');
+    }
+
+    return this.hodKpiService.saveEntryComment(user.id, user.role, kpiId, index, body.comment || '');
   }
 }

--- a/apps/server/src/hod/kpi-management/kpi-management.service.ts
+++ b/apps/server/src/hod/kpi-management/kpi-management.service.ts
@@ -4,12 +4,14 @@ import { UserRole, KpiStatus } from '@repo/db/prisma/client';
 import { ExcelService, ExcelValidationService } from 'src/services/excel.service';
 import { ExcelTemplateResponseDto } from 'src/coordinator/dto/excel.dto';
 import { ExcelUploadResponseDto } from 'src/coordinator/dto/excel-upload.dto';
+import { QcReviewService } from 'src/qc/review/qc-review.service';
 import type { FormElementInstance } from '@workspace/types/types';
 @Injectable()
 export class HodKpiService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly excelService: ExcelService,
+    private readonly qcReviewService: QcReviewService,
   ) {}
   private assertHodRole(role: UserRole) {
     if (role !== UserRole.HOD) throw new ForbiddenException('Only HOD users can perform this action');
@@ -569,5 +571,19 @@ export class HodKpiService {
         dataSaved: false,
       };
     }
+  }
+
+  /**
+   * Get entry comments for a KPI (delegates to QC service)
+   */
+  async getEntryComments(userId: string, userRole: UserRole, kpiId: string) {
+    return this.qcReviewService.getEntryComments(userId, userRole, kpiId);
+  }
+
+  /**
+   * Save entry comment for a KPI (delegates to QC service)
+   */
+  async saveEntryComment(userId: string, userRole: UserRole, kpiId: string, entryIndex: number, comment: string) {
+    return this.qcReviewService.saveEntryComment(userId, userRole, kpiId, entryIndex, comment);
   }
 }

--- a/apps/server/src/qc/review/qc-review.controller.ts
+++ b/apps/server/src/qc/review/qc-review.controller.ts
@@ -58,6 +58,22 @@ export class QcReviewController {
     return this.reviewService.saveEntryComment(user.id, user.role, kpiId, index, body.comment || '');
   }
 
+  @Patch('kpis/:kpiId/entries/:entryIndex/hod-comment')
+  @Roles(UserRole.HOD)
+  async saveHodEntryComment(
+    @CurrentUser() user: RequestUser,
+    @Param('kpiId') kpiId: string,
+    @Param('entryIndex') entryIndex: string,
+    @Body() body: { comment: string },
+  ) {
+    const index = parseInt(entryIndex, 10);
+    if (isNaN(index)) {
+      throw new BadRequestException('Invalid entry index');
+    }
+
+    return this.reviewService.saveHodEntryComment(user.id, user.role, kpiId, index, body.comment || '');
+  }
+
   @Get('kpis/:kpiId/entry-comments')
   @Roles(UserRole.QAC, UserRole.HOD, UserRole.FACULTY)
   async getEntryComments(@CurrentUser() user: RequestUser, @Param('kpiId') kpiId: string) {

--- a/apps/server/src/qc/review/qc-review.service.ts
+++ b/apps/server/src/qc/review/qc-review.service.ts
@@ -258,11 +258,11 @@ export class QcReviewService {
     }
 
     const existingMetrics = (kpi.kpi_calculated_metrics ?? {}) as Record<string, unknown>;
-    const existingComments = (existingMetrics.entry_comments as Record<string, unknown>) || {};
+    const existingQcComments = (existingMetrics.qc_comments as Record<string, unknown>) || {};
 
-    // Update or add comment
-    const updatedComments = {
-      ...existingComments,
+    // Update or add QC comment
+    const updatedQcComments = {
+      ...existingQcComments,
       [entryIndex.toString()]: {
         comment: comment.trim(),
         reviewed_by: user.user_name ?? user.user_email ?? userId,
@@ -273,12 +273,14 @@ export class QcReviewService {
 
     // If comment is empty, remove the entry
     if (!comment.trim()) {
-      delete updatedComments[entryIndex.toString()];
+      delete updatedQcComments[entryIndex.toString()];
     }
 
     const updatedMetrics = {
       ...existingMetrics,
-      entry_comments: updatedComments,
+      qc_comments: updatedQcComments,
+      // Keep backward compatibility with existing entry_comments field
+      entry_comments: updatedQcComments,
     };
 
     await this.prisma.departmentKpi.update({
@@ -290,6 +292,87 @@ export class QcReviewService {
 
     return {
       message: 'Entry comment saved successfully',
+      data: {
+        entryIndex,
+        comment: comment.trim(),
+        reviewed_by: user.user_name ?? user.user_email ?? userId,
+        reviewed_at: new Date().toISOString(),
+      },
+    };
+  }
+
+  async saveHodEntryComment(userId: string, userRole: UserRole, kpiId: string, entryIndex: number, comment: string) {
+    if (!userId) throw new ForbiddenException('User not authenticated');
+
+    if (userRole !== UserRole.HOD) {
+      throw new ForbiddenException('Only HOD can save department comments');
+    }
+
+    if (entryIndex < 0) {
+      throw new BadRequestException('Invalid entry index');
+    }
+
+    const kpi = await this.prisma.departmentKpi.findUnique({
+      where: { id: kpiId },
+      include: {
+        department: { select: { hod_id: true } },
+      },
+    });
+
+    if (!kpi) throw new NotFoundException('KPI not found');
+
+    // Verify HOD has access to this KPI
+    if (kpi.department?.hod_id !== userId) {
+      throw new ForbiddenException('You do not have access to this KPI');
+    }
+
+    // Get user information for comment tracking
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { user_name: true, user_email: true },
+    });
+    if (!user) throw new NotFoundException('User not found');
+
+    // Verify entry exists
+    const formResponses = (kpi.form_responses || {}) as Record<string, unknown>;
+    const entries = (formResponses['entries'] as unknown[]) || [];
+    if (entryIndex >= entries.length) {
+      throw new BadRequestException('Entry index out of range');
+    }
+
+    const existingMetrics = (kpi.kpi_calculated_metrics ?? {}) as Record<string, unknown>;
+    const existingHodComments = (existingMetrics.hod_comments as Record<string, unknown>) || {};
+
+    // Update or add HOD comment
+    const updatedHodComments = {
+      ...existingHodComments,
+      [entryIndex.toString()]: {
+        comment: comment.trim(),
+        reviewed_by: user.user_name ?? user.user_email ?? userId,
+        reviewed_by_id: userId,
+        reviewed_at: new Date().toISOString(),
+      },
+    };
+
+    // If comment is empty, remove the entry
+    if (!comment.trim()) {
+      delete updatedHodComments[entryIndex.toString()];
+    }
+
+    const updatedMetrics = {
+      ...existingMetrics,
+      hod_comments: updatedHodComments,
+    };
+
+    await this.prisma.departmentKpi.update({
+      where: { id: kpiId },
+      data: {
+        kpi_calculated_metrics: updatedMetrics as object,
+      },
+    });
+
+    return {
+      message: 'HOD comment saved successfully',
       data: {
         entryIndex,
         comment: comment.trim(),
@@ -342,11 +425,20 @@ export class QcReviewService {
     }
 
     const metrics = (kpi.kpi_calculated_metrics ?? {}) as Record<string, unknown>;
+    const qcComments = (metrics.qc_comments as Record<string, unknown>) || {};
+    const hodComments = (metrics.hod_comments as Record<string, unknown>) || {};
+
+    // For backward compatibility, check if entry_comments exists and merge with qc_comments
     const entryComments = (metrics.entry_comments as Record<string, unknown>) || {};
+    const mergedQcComments =
+      Object.keys(entryComments).length > 0 && Object.keys(qcComments).length === 0 ? entryComments : qcComments;
 
     return {
       kpiId,
-      entryComments,
+      qcComments: mergedQcComments,
+      hodComments,
+      // Keep backward compatibility
+      entryComments: mergedQcComments,
     };
   }
 }

--- a/apps/web/app/(dashboards)/hod/kpi-management/[id]/page.tsx
+++ b/apps/web/app/(dashboards)/hod/kpi-management/[id]/page.tsx
@@ -8,7 +8,10 @@ import {
 } from "@/queries/hod/kpi";
 import { useReviewCoordinatorSubmission } from "@/queries/hod/coordinator-workflow";
 import { useDownloadHodExcelTemplate } from "@/queries/hod/excel";
-import { useGetEntryComments } from "@/queries/qc/review";
+import {
+  useGetEntryComments,
+  useSaveHodEntryComment,
+} from "@/queries/qc/review";
 import { HodExcelUploadDialog } from "@/components/hod/ExcelUploadDialog";
 import { FormElementType, FormElementInstance } from "@/lib/types";
 import ReadOnlyFormTable from "@/components/qc/readonly-form-table";

--- a/apps/web/app/(dashboards)/qc/review/[kpiId]/page.tsx
+++ b/apps/web/app/(dashboards)/qc/review/[kpiId]/page.tsx
@@ -6,6 +6,7 @@ import {
   useUpdateKpiStatus,
   useGetEntryComments,
   useSaveEntryComment,
+  useSaveHodEntryComment,
 } from "@/queries/qc/review";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import {
@@ -40,12 +41,17 @@ export default function QcKpiReviewPage() {
   const { mutate: updateStatus, isPending: updating } = useUpdateKpiStatus();
   const { mutate: saveEntryComment, isPending: savingComment } =
     useSaveEntryComment();
+  const { mutate: saveHodEntryComment, isPending: savingHodComment } =
+    useSaveHodEntryComment();
   const { mutate: downloadWorkbook, isPending: downloadingWorkbook } =
     useDownloadDepartmentKpiWorkbook();
   const [remark, setRemark] = useState("");
   const [showPanel, setShowPanel] = useState(false);
   const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
   const [savingCommentForRow, setSavingCommentForRow] = useState<
+    Record<number, boolean>
+  >({});
+  const [savingHodCommentForRow, setSavingHodCommentForRow] = useState<
     Record<number, boolean>
   >({});
 
@@ -73,6 +79,30 @@ export default function QcKpiReviewPage() {
         },
         onError: () => {
           setSavingCommentForRow((prev) => ({ ...prev, [entryIndex]: false }));
+        },
+      },
+    );
+  };
+
+  const handleSaveHodEntryComment = (entryIndex: number, comment: string) => {
+    if (!kpiId) return;
+
+    setSavingHodCommentForRow((prev) => ({ ...prev, [entryIndex]: true }));
+
+    saveHodEntryComment(
+      { kpiId, entryIndex, comment },
+      {
+        onSuccess: () => {
+          setSavingHodCommentForRow((prev) => ({
+            ...prev,
+            [entryIndex]: false,
+          }));
+        },
+        onError: () => {
+          setSavingHodCommentForRow((prev) => ({
+            ...prev,
+            [entryIndex]: false,
+          }));
         },
       },
     );
@@ -303,7 +333,8 @@ export default function QcKpiReviewPage() {
                 },
               );
               const entries = (data as any).form_responses?.entries || [];
-              const canEditComments = user?.role === "QAC";
+              const canEditQcComments = user?.role === "QAC";
+              const canEditHodComments = user?.role === "HOD";
               const showComments = ["QAC", "HOD", "FACULTY"].includes(
                 user?.role || "",
               );
@@ -313,10 +344,15 @@ export default function QcKpiReviewPage() {
                   elements={elements}
                   entries={entries}
                   enableRowComments={showComments}
+                  qcComments={entryCommentsData?.qcComments || {}}
+                  hodComments={entryCommentsData?.hodComments || {}}
                   entryComments={entryCommentsData?.entryComments || {}}
-                  canEditComments={canEditComments}
-                  onSaveComment={handleSaveEntryComment}
-                  isSavingComment={savingCommentForRow}
+                  canEditQcComments={canEditQcComments}
+                  canEditHodComments={canEditHodComments}
+                  onSaveQcComment={handleSaveEntryComment}
+                  onSaveHodComment={handleSaveHodEntryComment}
+                  isSavingQcComment={savingCommentForRow}
+                  isSavingHodComment={savingHodCommentForRow}
                 />
               );
             })()}

--- a/apps/web/components/formbuilder/table-rendered.tsx
+++ b/apps/web/components/formbuilder/table-rendered.tsx
@@ -55,7 +55,11 @@ import { useDownloadExcelTemplate } from "@/queries/excel";
 import type { UseMutationResult } from "@tanstack/react-query";
 import { ExcelUploadDialog } from "./ExcelUploadDialog";
 import { FrontendExcelUploadDialog } from "../common/FrontendExcelUploadDialog";
-import { useGetEntryComments, useSaveEntryComment } from "@/queries/qc/review";
+import {
+  useGetEntryComments,
+  useSaveEntryComment,
+  useSaveHodEntryComment,
+} from "@/queries/qc/review";
 interface TableFormRendererProps {
   name: string;
   elements: FormElementInstance[];
@@ -120,11 +124,36 @@ export default function TableFormRenderer({
     : defaultSaveHook;
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // QC Comments functionality
+  // Comments functionality
   const { data: entryCommentsData } = useGetEntryComments(
     enableQcComments && kpiId ? kpiId : null,
   );
   const { mutate: saveEntryComment } = useSaveEntryComment();
+  const { mutate: saveHodEntryComment } = useSaveHodEntryComment();
+
+  const [editingQcComment, setEditingQcComment] = useState<number | null>(null);
+  const [editingHodComment, setEditingHodComment] = useState<number | null>(
+    null,
+  );
+  const [qcCommentValues, setQcCommentValues] = useState<
+    Record<number, string>
+  >({});
+  const [hodCommentValues, setHodCommentValues] = useState<
+    Record<number, string>
+  >({});
+  const [savingQcCommentForRow, setSavingQcCommentForRow] = useState<
+    Record<number, boolean>
+  >({});
+  const [savingHodCommentForRow, setSavingHodCommentForRow] = useState<
+    Record<number, boolean>
+  >({});
+
+  const canEditQcComments = userRole === "QAC";
+  const canEditHodComments = userRole === "HOD";
+  const showComments =
+    enableQcComments && ["QAC", "HOD", "FACULTY"].includes(userRole || "");
+
+  // Backward compatibility
   const [editingComment, setEditingComment] = useState<number | null>(null);
   const [commentValues, setCommentValues] = useState<Record<number, string>>(
     {},
@@ -132,10 +161,7 @@ export default function TableFormRenderer({
   const [savingCommentForRow, setSavingCommentForRow] = useState<
     Record<number, boolean>
   >({});
-
   const canEditComments = userRole === "QAC";
-  const showComments =
-    enableQcComments && ["QAC", "HOD", "FACULTY"].includes(userRole || "");
 
   // Excel operations
   const defaultDownloadHook = useDownloadExcelTemplate();
@@ -150,6 +176,93 @@ export default function TableFormRenderer({
   const localStorageKey = `kpi-form-draft-${id}`;
 
   // QC Comments handlers
+  const handleQcCommentChange = (rowIndex: number, value: string) => {
+    setQcCommentValues((prev) => ({
+      ...prev,
+      [rowIndex]: value,
+    }));
+  };
+
+  const handleHodCommentChange = (rowIndex: number, value: string) => {
+    setHodCommentValues((prev) => ({
+      ...prev,
+      [rowIndex]: value,
+    }));
+  };
+
+  const handleSaveQcComment = (rowIndex: number) => {
+    if (!kpiId) return;
+
+    const comment = qcCommentValues[rowIndex] || "";
+    setSavingQcCommentForRow((prev) => ({ ...prev, [rowIndex]: true }));
+
+    saveEntryComment(
+      { kpiId, entryIndex: rowIndex, comment },
+      {
+        onSuccess: () => {
+          setSavingQcCommentForRow((prev) => ({ ...prev, [rowIndex]: false }));
+          setEditingQcComment(null);
+        },
+        onError: () => {
+          setSavingQcCommentForRow((prev) => ({ ...prev, [rowIndex]: false }));
+        },
+      },
+    );
+  };
+
+  const handleSaveHodComment = (rowIndex: number) => {
+    if (!kpiId) return;
+
+    const comment = hodCommentValues[rowIndex] || "";
+    setSavingHodCommentForRow((prev) => ({ ...prev, [rowIndex]: true }));
+
+    saveHodEntryComment(
+      { kpiId, entryIndex: rowIndex, comment },
+      {
+        onSuccess: () => {
+          setSavingHodCommentForRow((prev) => ({ ...prev, [rowIndex]: false }));
+          setEditingHodComment(null);
+        },
+        onError: () => {
+          setSavingHodCommentForRow((prev) => ({ ...prev, [rowIndex]: false }));
+        },
+      },
+    );
+  };
+
+  const startEditingQcComment = (rowIndex: number) => {
+    const existingComment =
+      entryCommentsData?.qcComments?.[rowIndex.toString()]?.comment ||
+      entryCommentsData?.entryComments?.[rowIndex.toString()]?.comment ||
+      "";
+    setQcCommentValues((prev) => ({
+      ...prev,
+      [rowIndex]: existingComment,
+    }));
+    setEditingQcComment(rowIndex);
+  };
+
+  const startEditingHodComment = (rowIndex: number) => {
+    const existingComment =
+      entryCommentsData?.hodComments?.[rowIndex.toString()]?.comment || "";
+    setHodCommentValues((prev) => ({
+      ...prev,
+      [rowIndex]: existingComment,
+    }));
+    setEditingHodComment(rowIndex);
+  };
+
+  const cancelEditingQcComment = () => {
+    setEditingQcComment(null);
+    setQcCommentValues({});
+  };
+
+  const cancelEditingHodComment = () => {
+    setEditingHodComment(null);
+    setHodCommentValues({});
+  };
+
+  // Backward compatibility functions
   const handleCommentChange = (rowIndex: number, value: string) => {
     setCommentValues((prev) => ({
       ...prev,
@@ -687,12 +800,20 @@ export default function TableFormRenderer({
                 ))}
                 {hasComplexElements && <TableHead>Additional Fields</TableHead>}
                 {showComments && (
-                  <TableHead className="w-[250px]">
-                    <div className="flex items-center gap-1">
-                      <MessageSquare className="w-4 h-4" />
-                      QC Comments
-                    </div>
-                  </TableHead>
+                  <>
+                    <TableHead className="w-[250px]">
+                      <div className="flex items-center gap-1">
+                        <MessageSquare className="w-4 h-4" />
+                        QC Comments
+                      </div>
+                    </TableHead>
+                    <TableHead className="w-[250px]">
+                      <div className="flex items-center gap-1">
+                        <MessageSquare className="w-4 h-4" />
+                        Department Comments
+                      </div>
+                    </TableHead>
+                  </>
                 )}
                 <TableHead className="w-[100px]">Actions</TableHead>
               </TableRow>
@@ -737,105 +858,198 @@ export default function TableFormRenderer({
                     </TableCell>
                   )}
                   {showComments && (
-                    <TableCell className="w-[250px]">
-                      <div className="space-y-2">
-                        {editingComment === rowIndex ? (
-                          <div className="space-y-2">
-                            <Textarea
-                              value={commentValues[rowIndex] || ""}
-                              onChange={(e) =>
-                                handleCommentChange(rowIndex, e.target.value)
-                              }
-                              placeholder="Add QC comment for this entry..."
-                              className="text-xs resize-none"
-                              rows={3}
-                            />
-                            <div className="flex gap-1">
-                              <Button
-                                size="sm"
-                                onClick={() => handleSaveComment(rowIndex)}
-                                disabled={savingCommentForRow[rowIndex]}
-                                className="h-6 px-2 text-xs"
-                              >
-                                {savingCommentForRow[rowIndex] ? (
-                                  "Saving..."
-                                ) : (
-                                  <>
-                                    <Save className="w-3 h-3 mr-1" />
-                                    Save
-                                  </>
-                                )}
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={cancelEditingComment}
-                                className="h-6 px-2 text-xs"
-                              >
-                                Cancel
-                              </Button>
-                            </div>
-                          </div>
-                        ) : (
-                          <div>
-                            {entryCommentsData?.entryComments?.[
-                              rowIndex.toString()
-                            ] ? (
-                              <div className="space-y-1">
-                                <div className="text-xs bg-muted/50 rounded p-2 border">
-                                  {
-                                    entryCommentsData.entryComments[
-                                      rowIndex.toString()
-                                    ]?.comment
-                                  }
-                                </div>
-                                <div className="text-[10px] text-muted-foreground">
-                                  By{" "}
-                                  {
-                                    entryCommentsData.entryComments[
-                                      rowIndex.toString()
-                                    ]?.reviewed_by
-                                  }{" "}
-                                  •{" "}
-                                  {entryCommentsData.entryComments[
-                                    rowIndex.toString()
-                                  ]?.reviewed_at &&
-                                    new Date(
-                                      entryCommentsData.entryComments[
-                                        rowIndex.toString()
-                                      ]!.reviewed_at,
-                                    ).toLocaleDateString()}
-                                </div>
-                                {canEditComments && (
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() =>
-                                      startEditingComment(rowIndex)
-                                    }
-                                    className="h-6 px-2 text-xs"
-                                  >
-                                    Edit
-                                  </Button>
-                                )}
-                              </div>
-                            ) : (
-                              canEditComments && (
+                    <>
+                      {/* QC Comments Column */}
+                      <TableCell className="w-[250px]">
+                        <div className="space-y-2">
+                          {editingQcComment === rowIndex ? (
+                            <div className="space-y-2">
+                              <Textarea
+                                value={qcCommentValues[rowIndex] || ""}
+                                onChange={(e) =>
+                                  handleQcCommentChange(
+                                    rowIndex,
+                                    e.target.value,
+                                  )
+                                }
+                                placeholder="Add QC comment for this entry..."
+                                className="text-xs resize-none"
+                                rows={3}
+                              />
+                              <div className="flex gap-1">
+                                <Button
+                                  size="sm"
+                                  onClick={() => handleSaveQcComment(rowIndex)}
+                                  disabled={savingQcCommentForRow[rowIndex]}
+                                  className="h-6 px-2 text-xs"
+                                >
+                                  {savingQcCommentForRow[rowIndex] ? (
+                                    "Saving..."
+                                  ) : (
+                                    <>
+                                      <Save className="w-3 h-3 mr-1" />
+                                      Save
+                                    </>
+                                  )}
+                                </Button>
                                 <Button
                                   size="sm"
                                   variant="outline"
-                                  onClick={() => startEditingComment(rowIndex)}
+                                  onClick={cancelEditingQcComment}
                                   className="h-6 px-2 text-xs"
                                 >
-                                  <MessageSquare className="w-3 h-3 mr-1" />
-                                  Add Comment
+                                  Cancel
                                 </Button>
-                              )
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </TableCell>
+                              </div>
+                            </div>
+                          ) : (
+                            <div>
+                              {(() => {
+                                const qcComments =
+                                  entryCommentsData?.qcComments ||
+                                  entryCommentsData?.entryComments ||
+                                  {};
+                                const comment = qcComments[rowIndex.toString()];
+                                return comment ? (
+                                  <div className="space-y-1">
+                                    <div className="text-xs bg-muted/50 rounded p-2 border">
+                                      {comment.comment}
+                                    </div>
+                                    <div className="text-[10px] text-muted-foreground">
+                                      By {comment.reviewed_by} •{" "}
+                                      {new Date(
+                                        comment.reviewed_at,
+                                      ).toLocaleDateString()}
+                                    </div>
+                                    {canEditQcComments && (
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() =>
+                                          startEditingQcComment(rowIndex)
+                                        }
+                                        className="h-6 px-2 text-xs"
+                                      >
+                                        Edit
+                                      </Button>
+                                    )}
+                                  </div>
+                                ) : (
+                                  canEditQcComments && (
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      onClick={() =>
+                                        startEditingQcComment(rowIndex)
+                                      }
+                                      className="h-6 px-2 text-xs"
+                                    >
+                                      <MessageSquare className="w-3 h-3 mr-1" />
+                                      Add Comment
+                                    </Button>
+                                  )
+                                );
+                              })()}
+                            </div>
+                          )}
+                        </div>
+                      </TableCell>
+
+                      {/* HOD Comments Column */}
+                      <TableCell className="w-[250px]">
+                        <div className="space-y-2">
+                          {editingHodComment === rowIndex ? (
+                            <div className="space-y-2">
+                              <Textarea
+                                value={hodCommentValues[rowIndex] || ""}
+                                onChange={(e) =>
+                                  handleHodCommentChange(
+                                    rowIndex,
+                                    e.target.value,
+                                  )
+                                }
+                                placeholder="Add department comment for this entry..."
+                                className="text-xs resize-none"
+                                rows={3}
+                              />
+                              <div className="flex gap-1">
+                                <Button
+                                  size="sm"
+                                  onClick={() => handleSaveHodComment(rowIndex)}
+                                  disabled={savingHodCommentForRow[rowIndex]}
+                                  className="h-6 px-2 text-xs"
+                                >
+                                  {savingHodCommentForRow[rowIndex] ? (
+                                    "Saving..."
+                                  ) : (
+                                    <>
+                                      <Save className="w-3 h-3 mr-1" />
+                                      Save
+                                    </>
+                                  )}
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={cancelEditingHodComment}
+                                  className="h-6 px-2 text-xs"
+                                >
+                                  Cancel
+                                </Button>
+                              </div>
+                            </div>
+                          ) : (
+                            <div>
+                              {(() => {
+                                const comment =
+                                  entryCommentsData?.hodComments?.[
+                                    rowIndex.toString()
+                                  ];
+                                return comment ? (
+                                  <div className="space-y-1">
+                                    <div className="text-xs bg-muted/50 rounded p-2 border">
+                                      {comment.comment}
+                                    </div>
+                                    <div className="text-[10px] text-muted-foreground">
+                                      By {comment.reviewed_by} •{" "}
+                                      {new Date(
+                                        comment.reviewed_at,
+                                      ).toLocaleDateString()}
+                                    </div>
+                                    {canEditHodComments && (
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() =>
+                                          startEditingHodComment(rowIndex)
+                                        }
+                                        className="h-6 px-2 text-xs"
+                                      >
+                                        Edit
+                                      </Button>
+                                    )}
+                                  </div>
+                                ) : (
+                                  canEditHodComments && (
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      onClick={() =>
+                                        startEditingHodComment(rowIndex)
+                                      }
+                                      className="h-6 px-2 text-xs"
+                                    >
+                                      <MessageSquare className="w-3 h-3 mr-1" />
+                                      Add Comment
+                                    </Button>
+                                  )
+                                );
+                              })()}
+                            </div>
+                          )}
+                        </div>
+                      </TableCell>
+                    </>
                   )}
                   <TableCell>
                     <Button

--- a/apps/web/components/qc/readonly-form-table.tsx
+++ b/apps/web/components/qc/readonly-form-table.tsx
@@ -28,7 +28,17 @@ interface ReadOnlyFormTableProps {
   compact?: boolean;
   // Row comments functionality
   enableRowComments?: boolean;
+  qcComments?: Record<string, EntryComment>;
+  hodComments?: Record<string, EntryComment>;
+  // Backward compatibility
   entryComments?: Record<string, EntryComment>;
+  canEditQcComments?: boolean;
+  canEditHodComments?: boolean;
+  onSaveQcComment?: (entryIndex: number, comment: string) => void;
+  onSaveHodComment?: (entryIndex: number, comment: string) => void;
+  isSavingQcComment?: Record<number, boolean>;
+  isSavingHodComment?: Record<number, boolean>;
+  // Legacy props for backward compatibility
   canEditComments?: boolean;
   onSaveComment?: (entryIndex: number, comment: string) => void;
   isSavingComment?: Record<number, boolean>;
@@ -41,44 +51,97 @@ export function ReadOnlyFormTable({
   rowNumbers = true,
   compact = true,
   enableRowComments = false,
+  qcComments = {},
+  hodComments = {},
   entryComments = {},
+  canEditQcComments = false,
+  canEditHodComments = false,
+  onSaveQcComment,
+  onSaveHodComment,
+  isSavingQcComment = {},
+  isSavingHodComment = {},
+  // Legacy props for backward compatibility
   canEditComments = false,
   onSaveComment,
   isSavingComment = {},
 }: ReadOnlyFormTableProps) {
-  const [commentValues, setCommentValues] = useState<Record<number, string>>(
-    {},
+  const [qcCommentValues, setQcCommentValues] = useState<
+    Record<number, string>
+  >({});
+  const [hodCommentValues, setHodCommentValues] = useState<
+    Record<number, string>
+  >({});
+  const [editingQcComment, setEditingQcComment] = useState<number | null>(null);
+  const [editingHodComment, setEditingHodComment] = useState<number | null>(
+    null,
   );
-  const [editingComment, setEditingComment] = useState<number | null>(null);
 
   const cols = React.useMemo(() => elements, [elements]);
   const cellPad = compact ? "px-3 py-2" : "px-4 py-2.5";
 
-  const handleCommentChange = (rowIndex: number, value: string) => {
-    setCommentValues((prev) => ({
+  // Handle backward compatibility
+  const effectiveQcComments =
+    Object.keys(qcComments).length > 0 ? qcComments : entryComments;
+  const effectiveCanEditQc = canEditQcComments || canEditComments;
+  const effectiveOnSaveQc = onSaveQcComment || onSaveComment;
+  const effectiveIsSavingQc =
+    Object.keys(isSavingQcComment).length > 0
+      ? isSavingQcComment
+      : isSavingComment;
+
+  const handleQcCommentChange = (rowIndex: number, value: string) => {
+    setQcCommentValues((prev) => ({
       ...prev,
       [rowIndex]: value,
     }));
   };
 
-  const handleSaveComment = (rowIndex: number) => {
-    const comment = commentValues[rowIndex] || "";
-    onSaveComment?.(rowIndex, comment);
-    setEditingComment(null);
+  const handleHodCommentChange = (rowIndex: number, value: string) => {
+    setHodCommentValues((prev) => ({
+      ...prev,
+      [rowIndex]: value,
+    }));
   };
 
-  const startEditingComment = (rowIndex: number) => {
-    const existingComment = entryComments[rowIndex.toString()]?.comment || "";
-    setCommentValues((prev) => ({
+  const handleSaveQcComment = (rowIndex: number) => {
+    const comment = qcCommentValues[rowIndex] || "";
+    effectiveOnSaveQc?.(rowIndex, comment);
+    setEditingQcComment(null);
+  };
+
+  const handleSaveHodComment = (rowIndex: number) => {
+    const comment = hodCommentValues[rowIndex] || "";
+    onSaveHodComment?.(rowIndex, comment);
+    setEditingHodComment(null);
+  };
+
+  const startEditingQcComment = (rowIndex: number) => {
+    const existingComment =
+      effectiveQcComments[rowIndex.toString()]?.comment || "";
+    setQcCommentValues((prev) => ({
       ...prev,
       [rowIndex]: existingComment,
     }));
-    setEditingComment(rowIndex);
+    setEditingQcComment(rowIndex);
   };
 
-  const cancelEditingComment = () => {
-    setEditingComment(null);
-    setCommentValues({});
+  const startEditingHodComment = (rowIndex: number) => {
+    const existingComment = hodComments[rowIndex.toString()]?.comment || "";
+    setHodCommentValues((prev) => ({
+      ...prev,
+      [rowIndex]: existingComment,
+    }));
+    setEditingHodComment(rowIndex);
+  };
+
+  const cancelEditingQcComment = () => {
+    setEditingQcComment(null);
+    setQcCommentValues({});
+  };
+
+  const cancelEditingHodComment = () => {
+    setEditingHodComment(null);
+    setHodCommentValues({});
   };
 
   if (!entries || entries.length === 0)
@@ -123,17 +186,30 @@ export function ReadOnlyFormTable({
               </TableHead>
             ))}
             {enableRowComments && (
-              <TableHead
-                className={
-                  "whitespace-nowrap font-semibold text-[11px] tracking-wide uppercase w-64 select-none " +
-                  cellPad
-                }
-              >
-                <div className="flex items-center gap-1">
-                  <MessageSquare className="w-3 h-3" />
-                  QC Comments
-                </div>
-              </TableHead>
+              <>
+                <TableHead
+                  className={
+                    "whitespace-nowrap font-semibold text-[11px] tracking-wide uppercase w-64 select-none " +
+                    cellPad
+                  }
+                >
+                  <div className="flex items-center gap-1">
+                    <MessageSquare className="w-3 h-3" />
+                    QC Comments
+                  </div>
+                </TableHead>
+                <TableHead
+                  className={
+                    "whitespace-nowrap font-semibold text-[11px] tracking-wide uppercase w-64 select-none " +
+                    cellPad
+                  }
+                >
+                  <div className="flex items-center gap-1">
+                    <MessageSquare className="w-3 h-3" />
+                    Department Comments
+                  </div>
+                </TableHead>
+              </>
             )}
           </TableRow>
         </TableHeader>
@@ -170,89 +246,177 @@ export function ReadOnlyFormTable({
                 </TableCell>
               ))}
               {enableRowComments && (
-                <TableCell className={cellPad + " align-top w-64"}>
-                  <div className="space-y-2">
-                    {editingComment === rI ? (
-                      <div className="space-y-2">
-                        <Textarea
-                          value={commentValues[rI] || ""}
-                          onChange={(e) =>
-                            handleCommentChange(rI, e.target.value)
-                          }
-                          placeholder="Add QC comment for this entry..."
-                          className="text-xs resize-none"
-                          rows={3}
-                        />
-                        <div className="flex gap-1">
-                          <Button
-                            size="sm"
-                            onClick={() => handleSaveComment(rI)}
-                            disabled={isSavingComment[rI]}
-                            className="h-6 px-2 text-xs"
-                          >
-                            {isSavingComment[rI] ? (
-                              "Saving..."
-                            ) : (
-                              <>
-                                <Save className="w-3 h-3 mr-1" />
-                                Save
-                              </>
-                            )}
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={cancelEditingComment}
-                            className="h-6 px-2 text-xs"
-                          >
-                            Cancel
-                          </Button>
+                <>
+                  {/* QC Comments Column */}
+                  <TableCell className={cellPad + " align-top w-64"}>
+                    <div className="space-y-2">
+                      {editingQcComment === rI ? (
+                        <div className="space-y-2">
+                          <Textarea
+                            value={qcCommentValues[rI] || ""}
+                            onChange={(e) =>
+                              handleQcCommentChange(rI, e.target.value)
+                            }
+                            placeholder="Add QC comment for this entry..."
+                            className="text-xs resize-none"
+                            rows={3}
+                          />
+                          <div className="flex gap-1">
+                            <Button
+                              size="sm"
+                              onClick={() => handleSaveQcComment(rI)}
+                              disabled={effectiveIsSavingQc[rI]}
+                              className="h-6 px-2 text-xs"
+                            >
+                              {effectiveIsSavingQc[rI] ? (
+                                "Saving..."
+                              ) : (
+                                <>
+                                  <Save className="w-3 h-3 mr-1" />
+                                  Save
+                                </>
+                              )}
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={cancelEditingQcComment}
+                              className="h-6 px-2 text-xs"
+                            >
+                              Cancel
+                            </Button>
+                          </div>
                         </div>
-                      </div>
-                    ) : (
-                      <div>
-                        {(() => {
-                          const comment = entryComments[rI.toString()];
-                          return comment ? (
-                            <div className="space-y-1">
-                              <div className="text-xs bg-muted/50 rounded p-2 border">
-                                {comment.comment}
+                      ) : (
+                        <div>
+                          {(() => {
+                            const comment = effectiveQcComments[rI.toString()];
+                            return comment ? (
+                              <div className="space-y-1">
+                                <div className="text-xs bg-muted/50 rounded p-2 border">
+                                  {comment.comment}
+                                </div>
+                                <div className="text-[10px] text-muted-foreground">
+                                  By {comment.reviewed_by} •{" "}
+                                  {new Date(
+                                    comment.reviewed_at,
+                                  ).toLocaleDateString()}
+                                </div>
+                                {effectiveCanEditQc && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => startEditingQcComment(rI)}
+                                    className="h-6 px-2 text-xs"
+                                  >
+                                    Edit
+                                  </Button>
+                                )}
                               </div>
-                              <div className="text-[10px] text-muted-foreground">
-                                By {comment.reviewed_by} •{" "}
-                                {new Date(
-                                  comment.reviewed_at,
-                                ).toLocaleDateString()}
-                              </div>
-                              {canEditComments && (
+                            ) : (
+                              effectiveCanEditQc && (
                                 <Button
                                   size="sm"
                                   variant="outline"
-                                  onClick={() => startEditingComment(rI)}
+                                  onClick={() => startEditingQcComment(rI)}
                                   className="h-6 px-2 text-xs"
                                 >
-                                  Edit
+                                  <MessageSquare className="w-3 h-3 mr-1" />
+                                  Add Comment
                                 </Button>
+                              )
+                            );
+                          })()}
+                        </div>
+                      )}
+                    </div>
+                  </TableCell>
+
+                  {/* HOD Comments Column */}
+                  <TableCell className={cellPad + " align-top w-64"}>
+                    <div className="space-y-2">
+                      {editingHodComment === rI ? (
+                        <div className="space-y-2">
+                          <Textarea
+                            value={hodCommentValues[rI] || ""}
+                            onChange={(e) =>
+                              handleHodCommentChange(rI, e.target.value)
+                            }
+                            placeholder="Add department comment for this entry..."
+                            className="text-xs resize-none"
+                            rows={3}
+                          />
+                          <div className="flex gap-1">
+                            <Button
+                              size="sm"
+                              onClick={() => handleSaveHodComment(rI)}
+                              disabled={isSavingHodComment[rI]}
+                              className="h-6 px-2 text-xs"
+                            >
+                              {isSavingHodComment[rI] ? (
+                                "Saving..."
+                              ) : (
+                                <>
+                                  <Save className="w-3 h-3 mr-1" />
+                                  Save
+                                </>
                               )}
-                            </div>
-                          ) : (
-                            canEditComments && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => startEditingComment(rI)}
-                                className="h-6 px-2 text-xs"
-                              >
-                                <MessageSquare className="w-3 h-3 mr-1" />
-                                Add Comment
-                              </Button>
-                            )
-                          );
-                        })()}
-                      </div>
-                    )}
-                  </div>
-                </TableCell>
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={cancelEditingHodComment}
+                              className="h-6 px-2 text-xs"
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div>
+                          {(() => {
+                            const comment = hodComments[rI.toString()];
+                            return comment ? (
+                              <div className="space-y-1">
+                                <div className="text-xs bg-muted/50 rounded p-2 border">
+                                  {comment.comment}
+                                </div>
+                                <div className="text-[10px] text-muted-foreground">
+                                  By {comment.reviewed_by} •{" "}
+                                  {new Date(
+                                    comment.reviewed_at,
+                                  ).toLocaleDateString()}
+                                </div>
+                                {canEditHodComments && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => startEditingHodComment(rI)}
+                                    className="h-6 px-2 text-xs"
+                                  >
+                                    Edit
+                                  </Button>
+                                )}
+                              </div>
+                            ) : (
+                              canEditHodComments && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => startEditingHodComment(rI)}
+                                  className="h-6 px-2 text-xs"
+                                >
+                                  <MessageSquare className="w-3 h-3 mr-1" />
+                                  Add Comment
+                                </Button>
+                              )
+                            );
+                          })()}
+                        </div>
+                      )}
+                    </div>
+                  </TableCell>
+                </>
               )}
             </TableRow>
           ))}

--- a/apps/web/queries/hod/entry-comments.ts
+++ b/apps/web/queries/hod/entry-comments.ts
@@ -1,0 +1,50 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { HodEntryCommentsService } from "@/services/hod/entry-comments.service";
+import { toast } from "sonner";
+
+export function useGetHodEntryComments(kpiId: string | null) {
+  return useQuery({
+    queryKey: ["hod-entry-comments", kpiId],
+    queryFn: async () => {
+      if (!kpiId) throw new Error("KPI ID required");
+      const res = await HodEntryCommentsService.getEntryComments(kpiId);
+      if (res.data) return res.data;
+      throw new Error(res.error?.message || "Failed to fetch entry comments");
+    },
+    enabled: !!kpiId,
+  });
+}
+
+export function useSaveHodEntryComment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      kpiId,
+      entryIndex,
+      comment,
+    }: {
+      kpiId: string;
+      entryIndex: number;
+      comment: string;
+    }) => {
+      const res = await HodEntryCommentsService.saveEntryComment(
+        kpiId,
+        entryIndex,
+        comment,
+      );
+      if (res.data) return res.data;
+      throw new Error(res.error?.message || "Failed to save comment");
+    },
+    onSuccess: (_data, vars) => {
+      toast.success("Comment saved");
+      queryClient.invalidateQueries({
+        queryKey: ["hod-entry-comments", vars.kpiId],
+      });
+      // Also invalidate the main KPI data query since comments might be part of it
+      queryClient.invalidateQueries({ queryKey: ["hod-kpi", vars.kpiId] });
+    },
+    onError: (err: any) => {
+      toast.error("Failed to save comment", { description: err.message });
+    },
+  });
+}

--- a/apps/web/queries/qc/review.ts
+++ b/apps/web/queries/qc/review.ts
@@ -99,7 +99,7 @@ export function useGetEntryComments(kpiId: string | null) {
   });
 }
 
-// Only QAC can save comments
+// Only QAC can save QC comments
 export function useSaveEntryComment() {
   const qc = useQueryClient();
   return useMutation({
@@ -126,6 +126,39 @@ export function useSaveEntryComment() {
     },
     onError: (err: any) => {
       toast.error("Failed to save comment", { description: err.message });
+    },
+  });
+}
+
+// Only HOD can save HOD comments
+export function useSaveHodEntryComment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      kpiId,
+      entryIndex,
+      comment,
+    }: {
+      kpiId: string;
+      entryIndex: number;
+      comment: string;
+    }) => {
+      const res = await QcReviewService.saveHodEntryComment(
+        kpiId,
+        entryIndex,
+        comment,
+      );
+      if (res.data) return res.data;
+      throw new Error(res.error?.message || "Failed to save HOD comment");
+    },
+    onSuccess: (_data, vars) => {
+      toast.success("Department comment saved");
+      qc.invalidateQueries({ queryKey: ["qc-entry-comments", vars.kpiId] });
+    },
+    onError: (err: any) => {
+      toast.error("Failed to save department comment", {
+        description: err.message,
+      });
     },
   });
 }

--- a/apps/web/services/hod/entry-comments.service.ts
+++ b/apps/web/services/hod/entry-comments.service.ts
@@ -1,0 +1,32 @@
+import { ApiClient } from "@/lib/api-client";
+
+export interface EntryComment {
+  comment: string;
+  reviewed_by: string;
+  reviewed_by_id: string;
+  reviewed_at: string;
+}
+
+export interface EntryCommentsResponse {
+  kpiId: string;
+  entryComments: Record<string, EntryComment>;
+}
+
+export class HodEntryCommentsService {
+  static async getEntryComments(kpiId: string) {
+    return ApiClient.get<EntryCommentsResponse>(
+      `/hod/kpi-management/kpi/${kpiId}/entry-comments`,
+    );
+  }
+
+  static async saveEntryComment(
+    kpiId: string,
+    entryIndex: number,
+    comment: string,
+  ) {
+    return ApiClient.put<{ message: string; data: EntryComment }>(
+      `/hod/kpi-management/kpi/${kpiId}/entries/${entryIndex}/comment`,
+      { comment },
+    );
+  }
+}

--- a/apps/web/services/qc/review.service.ts
+++ b/apps/web/services/qc/review.service.ts
@@ -24,6 +24,9 @@ export interface EntryComment {
 
 export interface EntryCommentsResponse {
   kpiId: string;
+  qcComments: Record<string, EntryComment>;
+  hodComments: Record<string, EntryComment>;
+  // Backward compatibility
   entryComments: Record<string, EntryComment>;
 }
 
@@ -52,6 +55,17 @@ export class QcReviewService {
   ) {
     return ApiClient.patch<{ message: string; data: EntryComment }>(
       `/qc/review/kpis/${kpiId}/entries/${entryIndex}/comment`,
+      { comment },
+    );
+  }
+
+  static async saveHodEntryComment(
+    kpiId: string,
+    entryIndex: number,
+    comment: string,
+  ) {
+    return ApiClient.patch<{ message: string; data: EntryComment }>(
+      `/qc/review/kpis/${kpiId}/entries/${entryIndex}/hod-comment`,
       { comment },
     );
   }


### PR DESCRIPTION
hod row-wise comment functionality added


https://github.com/user-attachments/assets/85c54aef-be97-4ff3-b774-94bb1f729536



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Department (HOD) comments alongside QC comments for KPI entries.
  - HODs can add and edit their own comments; QC retains separate comment flow.
  - Role-based permissions: only QC can edit QC comments; only HOD can edit Department comments.

- UI/UX
  - Read-only tables now show two comment columns: QC Comments and Department Comments.
  - In-place editing with per-row Save/Cancel, loading states, and success/error toasts.
  - Improved comment fetching and saving behavior with backward-compatible display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->