### PR TITLE
fix: pdf download button

### DIFF
--- a/apps/web/components/formbuilder/table-rendered.tsx
+++ b/apps/web/components/formbuilder/table-rendered.tsx
@@ -775,7 +775,7 @@ export default function TableFormRenderer({
             ) : (
               <ExcelUploadDialog kpiId={id} />
             )}
-            <Button
+            {/*<Button
               variant="outline"
               onClick={() => {
                 toast.success("PDF download functionality will be implemented");
@@ -783,7 +783,7 @@ export default function TableFormRenderer({
             >
               <FileText className="mr-2 h-4 w-4" />
               Download PDF
-            </Button>
+            </Button>*/}
           </div>
         </div>
       </CardHeader>


### PR DESCRIPTION
<img width="1678" height="902" alt="image" src="https://github.com/user-attachments/assets/b927f4b2-9f59-4d66-a570-05e75136b35b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Download PDF button from table-rendered forms. The control is now hidden with no changes to underlying behavior or data. Users will no longer be able to initiate PDF downloads from this view. Other functionality remains unchanged. This streamlines the interface and avoids confusion around unavailable exports. Existing actions and submissions continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->