### PR TITLE
Fix: format timestamps to show date and time consistently in UI

### DIFF
--- a/apps/web/app/(dashboards)/faculty/kpi-management/[id]/page.tsx
+++ b/apps/web/app/(dashboards)/faculty/kpi-management/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { format } from "date-fns";
 import TableFormRenderer from "@/components/formbuilder/table-rendered";
 import { useGetKpiDetails, useSaveHodKpiData } from "@/queries/hod/kpi";
 import {
@@ -160,7 +161,10 @@ export default function FacultyKpiPage({
                       <div className="flex justify-between items-center mt-2">
                         <p className="text-xs text-muted-foreground">
                           Reviewed on{" "}
-                          {new Date(hodReview.reviewed_at).toLocaleString()}
+                          {format(
+                            new Date(hodReview.reviewed_at),
+                            "dd/MM/yyyy HH:mm:ss",
+                          )}
                         </p>
                         {hodReview.by && (
                           <p className="text-xs text-muted-foreground">

--- a/apps/web/app/(dashboards)/hod/ViewKPI/page.tsx
+++ b/apps/web/app/(dashboards)/hod/ViewKPI/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Button } from "@workspace/ui/components/button";
+import { format } from "date-fns";
 import {
   Card,
   CardContent,
@@ -84,7 +85,7 @@ export default function FormsPage() {
                 <div>
                   <CardTitle>{form.title}</CardTitle>
                   <CardDescription>
-                    Created on {new Date(form.createdAt).toLocaleDateString()}
+                    Created on {format(new Date(form.createdAt), "dd/MM/yyyy")}
                   </CardDescription>
                 </div>
                 <Badge>{form.value}</Badge>

--- a/apps/web/app/(dashboards)/hod/kpi-management/[id]/page.tsx
+++ b/apps/web/app/(dashboards)/hod/kpi-management/[id]/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 import React from "react";
-import { format } from "date-fns";
+
+import { format, isValid } from "date-fns";
+
+const formatTimestamp = (value: string | Date) => {
+  const d = new Date(value);
+  return isValid(d) ? format(d, "dd/MM/yyyy HH:mm:ss") : "—";
+};
 import TableFormRenderer from "@/components/formbuilder/table-rendered";
 import {
   useGetKpiDetails,

--- a/apps/web/app/(dashboards)/hod/kpi-management/[id]/page.tsx
+++ b/apps/web/app/(dashboards)/hod/kpi-management/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { format } from "date-fns";
 import TableFormRenderer from "@/components/formbuilder/table-rendered";
 import {
   useGetKpiDetails,
@@ -501,7 +502,10 @@ export default function HodKpiPage({
                                       : review.action}
                               </Badge>
                               <span className="text-muted-foreground">
-                                {new Date(review.at).toLocaleString()}
+                                {format(
+                                  new Date(review.at),
+                                  "dd/MM/yyyy HH:mm:ss",
+                                )}
                               </span>
                             </div>
                             {review.remark && (
@@ -594,7 +598,7 @@ export default function HodKpiPage({
                                   : review.action}
                           </Badge>
                           <span className="text-xs text-muted-foreground">
-                            {new Date(review.at).toLocaleString()}
+                            {format(new Date(review.at), "dd/MM/yyyy HH:mm:ss")}
                           </span>
                         </div>
                         {review.remark && (

--- a/apps/web/app/(dashboards)/qc/dashboard/page.tsx
+++ b/apps/web/app/(dashboards)/qc/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "@workspace/ui/components/badge";
+import { format } from "date-fns";
 import {
   Card,
   CardContent,
@@ -369,7 +370,7 @@ export default function QACDashboard() {
                       </TableCell>
                       <TableCell>
                         {dept.lastSubmission
-                          ? new Date(dept.lastSubmission).toLocaleDateString()
+                          ? format(new Date(dept.lastSubmission), "dd/MM/yyyy")
                           : "N/A"}
                       </TableCell>
                     </TableRow>

--- a/apps/web/app/(dashboards)/qc/review/[kpiId]/page.tsx
+++ b/apps/web/app/(dashboards)/qc/review/[kpiId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useParams, useRouter } from "next/navigation";
+import { format } from "date-fns";
 import {
   useDownloadDepartmentKpiWorkbook,
   useGetKpi,
@@ -285,7 +286,7 @@ export default function QcKpiReviewPage() {
                             <div className="flex justify-between mb-1">
                               <span className="font-medium">{r.action}</span>
                               <span className="text-muted-foreground">
-                                {new Date(r.at).toLocaleString()}
+                                {format(new Date(r.at), "dd/MM/yyyy HH:mm:ss")}
                               </span>
                             </div>
                             {r.remark && (

--- a/apps/web/components/common/FrontendExcelUploadDialog.tsx
+++ b/apps/web/components/common/FrontendExcelUploadDialog.tsx
@@ -148,7 +148,7 @@ export function FrontendExcelUploadDialog({
     return {
       isValid: false,
       processedValue: value,
-      error: `Invalid date format for field '${fieldName}'. Expected: YYYY-MM-DD, MM/DD/YYYY, or Excel date serial number`,
+      error: `Invalid date format for field '${fieldName}'. Expected: DD/MM/YYYY or Excel date serial number`,
     };
   };
 
@@ -573,8 +573,8 @@ export function FrontendExcelUploadDialog({
                                 <span className="font-medium">
                                   {header.label}:
                                 </span>{" "}
-                                Use date format (YYYY-MM-DD, MM/DD/YYYY) or
-                                Excel serial number (e.g., 4638 for 2024-01-01)
+                                Use date format (DD/MM/YYYY) or Excel serial
+                                number (e.g., 4638 for 2024-01-01)
                               </div>
                             );
                           }

--- a/apps/web/components/common/ReviewPanel.tsx
+++ b/apps/web/components/common/ReviewPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import { format } from "date-fns";
+import { format, isValid } from "date-fns";
 import { Button } from "@workspace/ui/components/button";
 import { Textarea } from "@workspace/ui/components/textarea";
 import { toast } from "sonner";
@@ -158,7 +158,12 @@ export function ReviewPanel({
                       <div className="flex justify-between mb-1">
                         <span className="font-medium">{review.action}</span>
                         <span className="text-muted-foreground">
-                          {format(new Date(review.at), "dd/MM/yyyy HH:mm:ss")}
+                          {(() => {
+                            const d = new Date(review.at);
+                            return isValid(d)
+                              ? format(d, "dd/MM/yyyy HH:mm:ss")
+                              : "—";
+                          })()}
                         </span>
                       </div>
                       {(review.remark || review.comments) && (

--- a/apps/web/components/common/ReviewPanel.tsx
+++ b/apps/web/components/common/ReviewPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from "react";
+import { format } from "date-fns";
 import { Button } from "@workspace/ui/components/button";
 import { Textarea } from "@workspace/ui/components/textarea";
 import { toast } from "sonner";
@@ -157,7 +158,7 @@ export function ReviewPanel({
                       <div className="flex justify-between mb-1">
                         <span className="font-medium">{review.action}</span>
                         <span className="text-muted-foreground">
-                          {new Date(review.at).toLocaleString()}
+                          {format(new Date(review.at), "dd/MM/yyyy HH:mm:ss")}
                         </span>
                       </div>
                       {(review.remark || review.comments) && (

--- a/apps/web/components/common/ReviewStatusDisplay.tsx
+++ b/apps/web/components/common/ReviewStatusDisplay.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { format } from "date-fns";
 import {
   Card,
   CardContent,
@@ -131,7 +132,7 @@ export function ReviewStatusDisplay({
                         {getStatusDisplayText(review.action)}
                       </Badge>
                       <span className="text-xs text-muted-foreground">
-                        {new Date(review.at).toLocaleString()}
+                        {format(new Date(review.at), "dd/MM/yyyy HH:mm:ss")}
                       </span>
                     </div>
                     {(review.remark || review.comments) && (

--- a/apps/web/components/formbuilder/ExcelUploadDialog.tsx
+++ b/apps/web/components/formbuilder/ExcelUploadDialog.tsx
@@ -350,7 +350,7 @@ export function ExcelUploadDialog({ kpiId, trigger }: ExcelUploadDialogProps) {
                           provided options for dropdown/radio fields
                         </p>
                         <p>
-                          4. <strong>Date Format:</strong> Use YYYY-MM-DD format
+                          4. <strong>Date Format:</strong> Use DD/MM/YYYY format
                           for dates
                         </p>
                         <p>

--- a/apps/web/components/formbuilder/element-settings.tsx
+++ b/apps/web/components/formbuilder/element-settings.tsx
@@ -129,6 +129,29 @@ export default function ElementSettings({
         return (
           <OptionsEditor element={element} updateElement={updateElement} />
         );
+      case "date-range":
+        return (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="minDate">Minimum Date</Label>
+              <Input
+                id="minDate"
+                type="date"
+                value={attributes.minDate || ""}
+                onChange={(e) => handleChange("minDate", e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="maxDate">Maximum Date</Label>
+              <Input
+                id="maxDate"
+                type="date"
+                value={attributes.maxDate || ""}
+                onChange={(e) => handleChange("maxDate", e.target.value)}
+              />
+            </div>
+          </div>
+        );
       case "file":
         return (
           <>

--- a/apps/web/components/formbuilder/form-element.tsx
+++ b/apps/web/components/formbuilder/form-element.tsx
@@ -34,6 +34,7 @@ import {
 import {
   AlignLeft,
   Calendar,
+  CalendarRange,
   CheckSquare,
   File,
   Grip,
@@ -96,6 +97,8 @@ export default function FormElement({
         return <RadioIcon size={18} />;
       case "date":
         return <Calendar size={18} />;
+      case "date-range":
+        return <CalendarRange size={18} />;
       case "email":
         return <Mail size={18} />;
       case "file":
@@ -187,6 +190,23 @@ export default function FormElement({
           <div className="space-y-2">
             <Label>{attributes.label}</Label>
             <Input type="date" />
+          </div>
+        );
+      case "date-range":
+        return (
+          <div className="space-y-2">
+            <Label>{attributes.label}</Label>
+            <div className="flex gap-2 items-center">
+              <Input type="date" className="w-full" disabled />
+              <span className="text-sm text-gray-500">to</span>
+              <Input type="date" className="w-full" disabled />
+            </div>
+            {(attributes.minDate || attributes.maxDate) && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Range: {attributes.minDate || "Any"} to{" "}
+                {attributes.maxDate || "Any"}
+              </p>
+            )}
           </div>
         );
       case "email":

--- a/apps/web/components/formbuilder/form-elements-sidebar.tsx
+++ b/apps/web/components/formbuilder/form-elements-sidebar.tsx
@@ -13,6 +13,7 @@ import type { FormElementType } from "@/lib/types";
 import {
   AlignLeft,
   Calendar,
+  CalendarRange,
   CheckSquare,
   File,
   Hash,
@@ -66,6 +67,11 @@ export default function FormElementsSidebar() {
     { type: "checkbox", icon: <CheckSquare size={18} />, label: "Checkbox" },
     { type: "radio", icon: <RadioIcon size={18} />, label: "Radio Group" },
     { type: "date", icon: <Calendar size={18} />, label: "Date" },
+    {
+      type: "date-range",
+      icon: <CalendarRange size={18} />,
+      label: "Date Range",
+    },
     { type: "email", icon: <Mail size={18} />, label: "Email" },
     { type: "file", icon: <File size={18} />, label: "File Upload" },
   ];

--- a/apps/web/components/formbuilder/table-rendered.tsx
+++ b/apps/web/components/formbuilder/table-rendered.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { format } from "date-fns";
 import type { FormElementInstance } from "@/lib/types";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
@@ -469,9 +470,15 @@ export default function TableFormRenderer({
   }, [entries, id, saveKpiData, isSubmitting, lastSavedEntries]);
   // Filter elements that can be displayed in a table (simple inputs)
   const tableElements = elements.filter((element) =>
-    ["text", "number", "email", "date", "select", "checkbox"].includes(
-      element.type,
-    ),
+    [
+      "text",
+      "number",
+      "email",
+      "date",
+      "date-range",
+      "select",
+      "checkbox",
+    ].includes(element.type),
   );
   // Complex elements that need a dialog (but can still be populated from Excel)
   const complexElements = elements.filter((element) =>
@@ -592,8 +599,48 @@ export default function TableFormRenderer({
         return;
       }
       elements.forEach((element) => {
-        if (element.attributes.required && !entry[element.id]) {
-          invalidRows.push(index + 1); // +1 for human-readable row numbers
+        const value = entry[element.id];
+
+        // Required check
+        if (element.attributes.required) {
+          if (!value) {
+            invalidRows.push(index + 1);
+          } else if (element.type === "date-range") {
+            const [start, end] = String(value).split("|");
+            if (!start || !end) {
+              if (!invalidRows.includes(index + 1)) invalidRows.push(index + 1);
+            }
+          }
+        }
+
+        // Date range specific validation
+        if (element.type === "date-range" && value) {
+          const [start, end] = String(value).split("|");
+
+          // Logic check: Start <= End
+          if (start && end && start > end) {
+            if (!invalidRows.includes(index + 1)) invalidRows.push(index + 1);
+          }
+
+          // Min date check
+          if (element.attributes.minDate) {
+            if (
+              (start && start < element.attributes.minDate) ||
+              (end && end < element.attributes.minDate)
+            ) {
+              if (!invalidRows.includes(index + 1)) invalidRows.push(index + 1);
+            }
+          }
+
+          // Max date check
+          if (element.attributes.maxDate) {
+            if (
+              (start && start > element.attributes.maxDate) ||
+              (end && end > element.attributes.maxDate)
+            ) {
+              if (!invalidRows.includes(index + 1)) invalidRows.push(index + 1);
+            }
+          }
         }
       });
     });
@@ -908,11 +955,18 @@ export default function TableFormRenderer({
                   };
 
                   const widthClass = getWidthClass(dynamicWidth);
+                  const isDateRange = element.type === "date-range";
+                  const finalWidthClass = isDateRange
+                    ? "w-[300px]"
+                    : widthClass;
+                  const maxWidthClass = isDateRange
+                    ? "max-w-[300px]"
+                    : "max-w-[160px]";
 
                   return (
                     <TableHead
                       key={element.id}
-                      className={`${widthClass} max-w-[160px] min-w-[100px] p-2 text-left align-middle border-r`}
+                      className={`${finalWidthClass} ${maxWidthClass} min-w-[100px] p-2 text-left align-middle border-r`}
                     >
                       <div className="w-full h-full overflow-hidden break-words leading-tight text-xs font-medium flex items-center">
                         <span>
@@ -1091,9 +1145,10 @@ export default function TableFormRenderer({
                                     </div>
                                     <div className="text-[10px] text-muted-foreground">
                                       By {comment.reviewed_by} •{" "}
-                                      {new Date(
-                                        comment.reviewed_at,
-                                      ).toLocaleDateString()}
+                                      {format(
+                                        new Date(comment.reviewed_at),
+                                        "dd/MM/yyyy",
+                                      )}
                                     </div>
                                     {canEditQcComments && (
                                       <Button
@@ -1186,9 +1241,10 @@ export default function TableFormRenderer({
                                     </div>
                                     <div className="text-[10px] text-muted-foreground">
                                       By {comment.reviewed_by} •{" "}
-                                      {new Date(
-                                        comment.reviewed_at,
-                                      ).toLocaleDateString()}
+                                      {format(
+                                        new Date(comment.reviewed_at),
+                                        "dd/MM/yyyy",
+                                      )}
                                     </div>
                                     {canEditHodComments && (
                                       <Button
@@ -1353,6 +1409,58 @@ function renderTableCellInput(
           className="h-8 w-full"
         />
       );
+    case "date-range": {
+      const parts = String(value || "").split("|");
+      const start = parts[0] || "";
+      const end = parts[1] || "";
+
+      // Simple validation for UI feedback
+      const isStartInvalid =
+        attributes.minDate &&
+        start &&
+        (start < attributes.minDate ||
+          (attributes.maxDate && start > attributes.maxDate));
+      const isEndInvalid =
+        attributes.minDate &&
+        end &&
+        (end < attributes.minDate ||
+          (attributes.maxDate && end > attributes.maxDate));
+      const isRangeInvalid = start && end && start > end;
+
+      return (
+        <div className="flex flex-col gap-1 min-w-[150px] py-1">
+          <div className="flex items-center gap-1">
+            <span className="text-[10px] text-gray-500 w-6">From</span>
+            <Input
+              type="date"
+              value={start}
+              onChange={(e) =>
+                updateEntry(rowIndex, id, `${e.target.value}|${end}`)
+              }
+              min={attributes.minDate}
+              max={attributes.maxDate}
+              className={`h-7 text-xs px-1 w-full ${isStartInvalid ? "border-red-500 bg-red-50" : ""}`}
+            />
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-[10px] text-gray-500 w-6">To</span>
+            <Input
+              type="date"
+              value={end}
+              onChange={(e) =>
+                updateEntry(rowIndex, id, `${start}|${e.target.value}`)
+              }
+              min={attributes.minDate}
+              max={attributes.maxDate}
+              className={`h-7 text-xs px-1 w-full ${isEndInvalid ? "border-red-500 bg-red-50" : ""}`}
+            />
+          </div>
+          {isRangeInvalid && (
+            <div className="text-[9px] text-red-500">Invalid range</div>
+          )}
+        </div>
+      );
+    }
     case "select":
       return (
         <Select

--- a/apps/web/components/formbuilder/table-rendered.tsx
+++ b/apps/web/components/formbuilder/table-rendered.tsx
@@ -1,6 +1,14 @@
 "use client";
 import { useState, useEffect } from "react";
 import { format } from "date-fns";
+const formatDateSafe = (
+  value: string | number | Date | null | undefined,
+  pattern: string,
+) => {
+  const d = new Date(value ?? "");
+  return Number.isNaN(d.getTime()) ? "—" : format(d, pattern);
+};
+
 import type { FormElementInstance } from "@/lib/types";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
@@ -603,7 +611,11 @@ export default function TableFormRenderer({
 
         // Required check
         if (element.attributes.required) {
-          if (!value) {
+          const isMissing =
+            value == null ||
+            value === "" ||
+            (element.type === "checkbox" ? value !== true : false);
+          if (isMissing) {
             invalidRows.push(index + 1);
           } else if (element.type === "date-range") {
             const [start, end] = String(value).split("|");
@@ -1145,8 +1157,8 @@ export default function TableFormRenderer({
                                     </div>
                                     <div className="text-[10px] text-muted-foreground">
                                       By {comment.reviewed_by} •{" "}
-                                      {format(
-                                        new Date(comment.reviewed_at),
+                                      {formatDateSafe(
+                                        comment.reviewed_at,
                                         "dd/MM/yyyy",
                                       )}
                                     </div>
@@ -1241,8 +1253,8 @@ export default function TableFormRenderer({
                                     </div>
                                     <div className="text-[10px] text-muted-foreground">
                                       By {comment.reviewed_by} •{" "}
-                                      {format(
-                                        new Date(comment.reviewed_at),
+                                      {formatDateSafe(
+                                        comment.reviewed_at,
                                         "dd/MM/yyyy",
                                       )}
                                     </div>

--- a/apps/web/components/formbuilder/table-rendered.tsx
+++ b/apps/web/components/formbuilder/table-rendered.tsx
@@ -613,7 +613,7 @@ export default function TableFormRenderer({
           }
         }
 
-        // Date range specific validation
+        // we are checking Date range specific validation
         if (element.type === "date-range" && value) {
           const [start, end] = String(value).split("|");
 
@@ -1416,15 +1416,14 @@ function renderTableCellInput(
 
       // Simple validation for UI feedback
       const isStartInvalid =
-        attributes.minDate &&
         start &&
-        (start < attributes.minDate ||
+        ((attributes.minDate && start < attributes.minDate) ||
           (attributes.maxDate && start > attributes.maxDate));
       const isEndInvalid =
-        attributes.minDate &&
         end &&
-        (end < attributes.minDate ||
+        ((attributes.minDate && end < attributes.minDate) ||
           (attributes.maxDate && end > attributes.maxDate));
+
       const isRangeInvalid = start && end && start > end;
 
       return (

--- a/apps/web/components/hod/ExcelUploadDialog.tsx
+++ b/apps/web/components/hod/ExcelUploadDialog.tsx
@@ -381,7 +381,7 @@ export function HodExcelUploadDialog({
                           provided options for dropdown/radio fields
                         </p>
                         <p>
-                          4. <strong>Date Format:</strong> Use YYYY-MM-DD format
+                          4. <strong>Date Format:</strong> Use DD/MM/YYYY format
                           for dates
                         </p>
                         <p>

--- a/apps/web/components/layout/kpi-management.tsx
+++ b/apps/web/components/layout/kpi-management.tsx
@@ -300,9 +300,9 @@ function Kpi3Form() {
                             )}
                           >
                             {field.value ? (
-                              format(field.value, "dd-MM-yyyy")
+                              format(field.value, "dd/MM/yyyy")
                             ) : (
-                              <span>DD-MM-YYYY</span>
+                              <span>DD/MM/YYYY</span>
                             )}
                             <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
                           </Button>
@@ -701,9 +701,9 @@ function Kpi4Form() {
                             )}
                           >
                             {field.value ? (
-                              format(field.value, "dd-MM-yyyy")
+                              format(field.value, "dd/MM/yyyy")
                             ) : (
-                              <span>DD-MM-YYYY</span>
+                              <span>DD/MM/YYYY</span>
                             )}
                             <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
                           </Button>

--- a/apps/web/components/qc/readonly-form-table.tsx
+++ b/apps/web/components/qc/readonly-form-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from "react";
+import { format } from "date-fns";
 import { FormElementInstance } from "@/lib/types";
 import { Button } from "@workspace/ui/components/button";
 import { Textarea } from "@workspace/ui/components/textarea";
@@ -438,9 +439,10 @@ export function ReadOnlyFormTable({
                                 </div>
                                 <div className="text-[10px] text-muted-foreground">
                                   By {comment.reviewed_by} •{" "}
-                                  {new Date(
-                                    comment.reviewed_at,
-                                  ).toLocaleDateString()}
+                                  {format(
+                                    new Date(comment.reviewed_at),
+                                    "dd/MM/yyyy",
+                                  )}
                                 </div>
                                 {effectiveCanEditQc && (
                                   <Button
@@ -523,9 +525,10 @@ export function ReadOnlyFormTable({
                                 </div>
                                 <div className="text-[10px] text-muted-foreground">
                                   By {comment.reviewed_by} •{" "}
-                                  {new Date(
-                                    comment.reviewed_at,
-                                  ).toLocaleDateString()}
+                                  {format(
+                                    new Date(comment.reviewed_at),
+                                    "dd/MM/yyyy",
+                                  )}
                                 </div>
                                 {canEditHodComments && (
                                   <Button
@@ -585,7 +588,9 @@ function Value({ value, type }: { value: any; type: string }) {
       );
     case "date": {
       const d = new Date(value);
-      return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
+      return Number.isNaN(d.getTime())
+        ? String(value)
+        : format(d, "dd/MM/yyyy");
     }
     case "number": {
       if (typeof value === "number") return value;

--- a/apps/web/components/qc/readonly-form-table.tsx
+++ b/apps/web/components/qc/readonly-form-table.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { format } from "date-fns";
 import { FormElementInstance } from "@/lib/types";
+
 import { Button } from "@workspace/ui/components/button";
 import { Textarea } from "@workspace/ui/components/textarea";
 import {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -38,6 +38,7 @@ export type FormElementType =
   | "checkbox"
   | "radio"
   | "date"
+  | "date-range"
   | "email"
   | "file";
 


### PR DESCRIPTION
#195 
Fix: remove hardcoded date formats and rely on native date picker (Issue 195), format timestamps to show date and time consistently in UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Date Range form element with UI, icon, sidebar entry, table support and validation for start/end and min/max.

* **Bug Fixes**
  * Standardized date/time displays to DD/MM/YYYY and DD/MM/YYYY HH:mm:ss across dashboards and review history.
  * Invalid or missing timestamps now show a clear placeholder.

* **Documentation**
  * Updated on-screen instructions and error messages to require DD/MM/YYYY (or Excel serial) date input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->